### PR TITLE
Joining groups and approving members

### DIFF
--- a/src/components/groups/ApprovedMembersList.tsx
+++ b/src/components/groups/ApprovedMembersList.tsx
@@ -1,0 +1,101 @@
+import { useNostr } from "@/hooks/useNostr";
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAuthor } from "@/hooks/useAuthor";
+import { Users } from "lucide-react";
+import { Link } from "react-router-dom";
+
+interface ApprovedMembersListProps {
+  communityId: string;
+}
+
+export function ApprovedMembersList({ communityId }: ApprovedMembersListProps) {
+  const { nostr } = useNostr();
+  
+  // Query for approved members
+  const { data: approvedMembersEvents, isLoading } = useQuery({
+    queryKey: ["approved-members-list", communityId],
+    queryFn: async (c) => {
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      
+      const events = await nostr.query([{ 
+        kinds: [14550],
+        "#a": [communityId],
+        limit: 10,
+      }], { signal });
+      
+      return events;
+    },
+    enabled: !!nostr && !!communityId,
+  });
+
+  // Extract all approved member pubkeys from the events
+  const approvedMembers = approvedMembersEvents?.flatMap(event => 
+    event.tags.filter(tag => tag[0] === "p").map(tag => tag[1])
+  ) || [];
+
+  // Remove duplicates
+  const uniqueApprovedMembers = [...new Set(approvedMembers)];
+  
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center">
+          <Users className="h-5 w-5 mr-2" />
+          Members ({uniqueApprovedMembers.length})
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-4">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="flex items-center gap-3">
+                <Skeleton className="h-10 w-10 rounded-full" />
+                <Skeleton className="h-4 w-32" />
+              </div>
+            ))}
+          </div>
+        ) : uniqueApprovedMembers.length === 0 ? (
+          <div className="text-center py-4 text-muted-foreground">
+            <p>No approved members yet</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {uniqueApprovedMembers.slice(0, 10).map((pubkey) => (
+              <MemberItem key={pubkey} pubkey={pubkey} />
+            ))}
+            {uniqueApprovedMembers.length > 10 && (
+              <div className="text-center text-sm text-muted-foreground pt-2">
+                + {uniqueApprovedMembers.length - 10} more members
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface MemberItemProps {
+  pubkey: string;
+}
+
+function MemberItem({ pubkey }: MemberItemProps) {
+  const author = useAuthor(pubkey);
+  const metadata = author.data?.metadata;
+  
+  const displayName = metadata?.name || pubkey.slice(0, 8);
+  const profileImage = metadata?.picture;
+  
+  return (
+    <Link to={`/profile/${pubkey}`} className="flex items-center gap-3 hover:bg-muted p-2 rounded-md transition-colors">
+      <Avatar>
+        <AvatarImage src={profileImage} />
+        <AvatarFallback>{displayName.slice(0, 2).toUpperCase()}</AvatarFallback>
+      </Avatar>
+      <span className="font-medium">{displayName}</span>
+    </Link>
+  );
+}

--- a/src/components/groups/JoinRequestButton.tsx
+++ b/src/components/groups/JoinRequestButton.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import { useNostrPublish } from "@/hooks/useNostrPublish";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useNostr } from "@/hooks/useNostr";
+import { useQuery } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { toast } from "sonner";
+import { UserPlus, CheckCircle, Clock } from "lucide-react";
+
+interface JoinRequestButtonProps {
+  communityId: string;
+}
+
+export function JoinRequestButton({ communityId }: JoinRequestButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [joinReason, setJoinReason] = useState("");
+  const { user } = useCurrentUser();
+  const { nostr } = useNostr();
+  const { mutateAsync: publishEvent, isPending } = useNostrPublish();
+
+  // Check if user has already requested to join
+  const { data: existingRequest, isLoading: isCheckingRequest } = useQuery({
+    queryKey: ["join-request", communityId, user?.pubkey],
+    queryFn: async (c) => {
+      if (!user) return null;
+      
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      const events = await nostr.query([{ 
+        kinds: [14551], 
+        authors: [user.pubkey],
+        "#a": [communityId]
+      }], { signal });
+      
+      return events.length > 0 ? events[0] : null;
+    },
+    enabled: !!nostr && !!user && !!communityId,
+  });
+
+  // Check if user is already an approved member
+  const { data: isApprovedMember, isLoading: isCheckingApproval } = useQuery({
+    queryKey: ["approved-member", communityId, user?.pubkey],
+    queryFn: async (c) => {
+      if (!user) return false;
+      
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      const events = await nostr.query([{ 
+        kinds: [14550], 
+        "#a": [communityId]
+      }], { signal });
+      
+      // Check if any of the approval lists include the user's pubkey
+      return events.some(event => 
+        event.tags.some(tag => tag[0] === "p" && tag[1] === user.pubkey)
+      );
+    },
+    enabled: !!nostr && !!user && !!communityId,
+  });
+
+  const handleRequestJoin = async () => {
+    if (!user) {
+      toast.error("You must be logged in to request to join a group");
+      return;
+    }
+
+    try {
+      // Create join request event (kind 14551)
+      await publishEvent({
+        kind: 14551,
+        tags: [
+          ["a", communityId],
+        ],
+        content: joinReason,
+      });
+      
+      toast.success("Join request sent successfully!");
+      setOpen(false);
+    } catch (error) {
+      console.error("Error sending join request:", error);
+      toast.error("Failed to send join request. Please try again.");
+    }
+  };
+
+  if (!user) {
+    return (
+      <Button variant="outline" disabled>
+        <UserPlus className="h-4 w-4 mr-2" />
+        Log in to join
+      </Button>
+    );
+  }
+
+  if (isCheckingRequest || isCheckingApproval) {
+    return (
+      <Button variant="outline" disabled>
+        <Clock className="h-4 w-4 mr-2 animate-spin" />
+        Checking status...
+      </Button>
+    );
+  }
+
+  if (isApprovedMember) {
+    return (
+      <Button variant="outline" disabled className="text-green-600 border-green-600">
+        <CheckCircle className="h-4 w-4 mr-2" />
+        Member
+      </Button>
+    );
+  }
+
+  if (existingRequest) {
+    return (
+      <Button variant="outline" disabled>
+        <Clock className="h-4 w-4 mr-2" />
+        Request pending
+      </Button>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline">
+          <UserPlus className="h-4 w-4 mr-2" />
+          Request to join
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Request to join this group</DialogTitle>
+          <DialogDescription>
+            Your request will be reviewed by the group moderators.
+          </DialogDescription>
+        </DialogHeader>
+        
+        <div className="py-4">
+          <label htmlFor="join-reason" className="text-sm font-medium mb-2 block">
+            Why do you want to join this group? (optional)
+          </label>
+          <Textarea
+            id="join-reason"
+            placeholder="Tell the moderators why you'd like to join..."
+            value={joinReason}
+            onChange={(e) => setJoinReason(e.target.value)}
+            className="min-h-[100px]"
+          />
+        </div>
+        
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+          <Button onClick={handleRequestJoin} disabled={isPending}>
+            {isPending ? "Sending..." : "Send request"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/groups/JoinRequestButton.tsx
+++ b/src/components/groups/JoinRequestButton.tsx
@@ -28,7 +28,7 @@ export function JoinRequestButton({ communityId }: JoinRequestButtonProps) {
       
       const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
       const events = await nostr.query([{ 
-        kinds: [14551], 
+        kinds: [4552], 
         authors: [user.pubkey],
         "#a": [communityId]
       }], { signal });
@@ -65,9 +65,9 @@ export function JoinRequestButton({ communityId }: JoinRequestButtonProps) {
     }
 
     try {
-      // Create join request event (kind 14551)
+      // Create join request event (kind 4552)
       await publishEvent({
-        kind: 14551,
+        kind: 4552,
         tags: [
           ["a", communityId],
         ],

--- a/src/components/groups/MemberManagement.tsx
+++ b/src/components/groups/MemberManagement.tsx
@@ -1,0 +1,350 @@
+import { useState } from "react";
+import { useNostr } from "@/hooks/useNostr";
+import { useNostrPublish } from "@/hooks/useNostrPublish";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAuthor } from "@/hooks/useAuthor";
+import { toast } from "sonner";
+import { UserPlus, Users, CheckCircle, XCircle } from "lucide-react";
+import { NostrEvent } from "@nostrify/nostrify";
+import { Link } from "react-router-dom";
+
+interface MemberManagementProps {
+  communityId: string;
+  isModerator: boolean;
+}
+
+export function MemberManagement({ communityId, isModerator }: MemberManagementProps) {
+  const { nostr } = useNostr();
+  const { user } = useCurrentUser();
+  const { mutateAsync: publishEvent } = useNostrPublish();
+  const [activeTab, setActiveTab] = useState("requests");
+
+  // Query for join requests
+  const { data: joinRequests, isLoading: isLoadingRequests, refetch: refetchRequests } = useQuery({
+    queryKey: ["join-requests", communityId],
+    queryFn: async (c) => {
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      
+      const events = await nostr.query([{ 
+        kinds: [14551],
+        "#a": [communityId],
+        limit: 50,
+      }], { signal });
+      
+      return events;
+    },
+    enabled: !!nostr && !!communityId,
+  });
+
+  // Query for approved members
+  const { data: approvedMembersEvents, isLoading: isLoadingMembers, refetch: refetchMembers } = useQuery({
+    queryKey: ["approved-members", communityId],
+    queryFn: async (c) => {
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      
+      const events = await nostr.query([{ 
+        kinds: [14550],
+        "#a": [communityId],
+        limit: 10,
+      }], { signal });
+      
+      return events;
+    },
+    enabled: !!nostr && !!communityId,
+  });
+
+  // Extract all approved member pubkeys from the events
+  const approvedMembers = approvedMembersEvents?.flatMap(event => 
+    event.tags.filter(tag => tag[0] === "p").map(tag => tag[1])
+  ) || [];
+
+  // Remove duplicates
+  const uniqueApprovedMembers = [...new Set(approvedMembers)];
+
+  // Filter out join requests from users who are already approved
+  const pendingRequests = joinRequests?.filter(request => 
+    !uniqueApprovedMembers.includes(request.pubkey)
+  ) || [];
+
+  const handleApproveUser = async (pubkey: string) => {
+    if (!user || !isModerator) {
+      toast.error("You must be a moderator to approve members");
+      return;
+    }
+
+    try {
+      // Get the latest approved members list
+      const latestList = approvedMembersEvents?.[0];
+      
+      // Create a new list or update the existing one
+      const tags = [
+        ["a", communityId],
+        ...uniqueApprovedMembers.map(pk => ["p", pk]),
+        ["p", pubkey] // Add the new member
+      ];
+
+      // Create approved members event (kind 14550)
+      await publishEvent({
+        kind: 14550,
+        tags,
+        content: "",
+      });
+      
+      toast.success("User approved successfully!");
+      
+      // Refetch data
+      refetchRequests();
+      refetchMembers();
+      
+      // Switch to members tab
+      setActiveTab("members");
+    } catch (error) {
+      console.error("Error approving user:", error);
+      toast.error("Failed to approve user. Please try again.");
+    }
+  };
+
+  const handleRemoveMember = async (pubkey: string) => {
+    if (!user || !isModerator) {
+      toast.error("You must be a moderator to remove members");
+      return;
+    }
+
+    try {
+      // Filter out the member to remove
+      const updatedMembers = uniqueApprovedMembers.filter(pk => pk !== pubkey);
+      
+      // Create a new list with the member removed
+      const tags = [
+        ["a", communityId],
+        ...updatedMembers.map(pk => ["p", pk])
+      ];
+
+      // Create updated approved members event (kind 14550)
+      await publishEvent({
+        kind: 14550,
+        tags,
+        content: "",
+      });
+      
+      toast.success("Member removed successfully!");
+      
+      // Refetch data
+      refetchMembers();
+    } catch (error) {
+      console.error("Error removing member:", error);
+      toast.error("Failed to remove member. Please try again.");
+    }
+  };
+
+  if (!isModerator) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Manage Members</CardTitle>
+        <CardDescription>
+          Review join requests and manage approved members
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Tabs value={activeTab} onValueChange={setActiveTab}>
+          <TabsList className="mb-4">
+            <TabsTrigger value="requests" className="flex items-center">
+              <UserPlus className="h-4 w-4 mr-2" />
+              Requests
+              {pendingRequests.length > 0 && (
+                <span className="ml-2 bg-primary text-primary-foreground rounded-full px-2 py-0.5 text-xs">
+                  {pendingRequests.length}
+                </span>
+              )}
+            </TabsTrigger>
+            <TabsTrigger value="members" className="flex items-center">
+              <Users className="h-4 w-4 mr-2" />
+              Members
+              <span className="ml-2 bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-xs">
+                {uniqueApprovedMembers.length}
+              </span>
+            </TabsTrigger>
+          </TabsList>
+          
+          <TabsContent value="requests">
+            {isLoadingRequests ? (
+              <div className="space-y-4">
+                {[1, 2, 3].map((i) => (
+                  <div key={i} className="flex items-center justify-between p-2 border rounded-md">
+                    <div className="flex items-center gap-3">
+                      <Skeleton className="h-10 w-10 rounded-full" />
+                      <div>
+                        <Skeleton className="h-4 w-32 mb-1" />
+                        <Skeleton className="h-3 w-24" />
+                      </div>
+                    </div>
+                    <div className="flex gap-2">
+                      <Skeleton className="h-9 w-20" />
+                      <Skeleton className="h-9 w-20" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : pendingRequests.length === 0 ? (
+              <div className="text-center py-8 text-muted-foreground">
+                <UserPlus className="h-12 w-12 mx-auto mb-3 opacity-20" />
+                <p>No pending join requests</p>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {pendingRequests.map((request) => (
+                  <JoinRequestItem 
+                    key={request.id} 
+                    request={request} 
+                    onApprove={() => handleApproveUser(request.pubkey)} 
+                  />
+                ))}
+              </div>
+            )}
+          </TabsContent>
+          
+          <TabsContent value="members">
+            {isLoadingMembers ? (
+              <div className="space-y-4">
+                {[1, 2, 3].map((i) => (
+                  <div key={i} className="flex items-center justify-between p-2 border rounded-md">
+                    <div className="flex items-center gap-3">
+                      <Skeleton className="h-10 w-10 rounded-full" />
+                      <div>
+                        <Skeleton className="h-4 w-32 mb-1" />
+                      </div>
+                    </div>
+                    <Skeleton className="h-9 w-20" />
+                  </div>
+                ))}
+              </div>
+            ) : uniqueApprovedMembers.length === 0 ? (
+              <div className="text-center py-8 text-muted-foreground">
+                <Users className="h-12 w-12 mx-auto mb-3 opacity-20" />
+                <p>No approved members yet</p>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {uniqueApprovedMembers.map((pubkey) => (
+                  <MemberItem 
+                    key={pubkey} 
+                    pubkey={pubkey} 
+                    onRemove={() => handleRemoveMember(pubkey)} 
+                  />
+                ))}
+              </div>
+            )}
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}
+
+interface JoinRequestItemProps {
+  request: NostrEvent;
+  onApprove: () => void;
+}
+
+function JoinRequestItem({ request, onApprove }: JoinRequestItemProps) {
+  const author = useAuthor(request.pubkey);
+  const metadata = author.data?.metadata;
+  
+  const displayName = metadata?.name || request.pubkey.slice(0, 8);
+  const profileImage = metadata?.picture;
+  const joinReason = request.content;
+  
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center justify-between p-3 border rounded-md gap-3">
+      <div className="flex items-center gap-3">
+        <Link to={`/profile/${request.pubkey}`}>
+          <Avatar>
+            <AvatarImage src={profileImage} />
+            <AvatarFallback>{displayName.slice(0, 2).toUpperCase()}</AvatarFallback>
+          </Avatar>
+        </Link>
+        <div>
+          <Link to={`/profile/${request.pubkey}`} className="font-medium hover:underline">
+            {displayName}
+          </Link>
+          <p className="text-xs text-muted-foreground">
+            Requested {new Date(request.created_at * 1000).toLocaleString()}
+          </p>
+          {joinReason && (
+            <p className="text-sm mt-1 max-w-md">
+              "{joinReason}"
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="flex gap-2 ml-auto">
+        <Button variant="outline" size="sm" className="text-red-600">
+          <XCircle className="h-4 w-4 mr-1" />
+          Decline
+        </Button>
+        <Button size="sm" onClick={onApprove}>
+          <CheckCircle className="h-4 w-4 mr-1" />
+          Approve
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+interface MemberItemProps {
+  pubkey: string;
+  onRemove: () => void;
+}
+
+function MemberItem({ pubkey, onRemove }: MemberItemProps) {
+  const author = useAuthor(pubkey);
+  const { user } = useCurrentUser();
+  const metadata = author.data?.metadata;
+  
+  const displayName = metadata?.name || pubkey.slice(0, 8);
+  const profileImage = metadata?.picture;
+  const isCurrentUser = user?.pubkey === pubkey;
+  
+  return (
+    <div className="flex items-center justify-between p-3 border rounded-md">
+      <div className="flex items-center gap-3">
+        <Link to={`/profile/${pubkey}`}>
+          <Avatar>
+            <AvatarImage src={profileImage} />
+            <AvatarFallback>{displayName.slice(0, 2).toUpperCase()}</AvatarFallback>
+          </Avatar>
+        </Link>
+        <div>
+          <Link to={`/profile/${pubkey}`} className="font-medium hover:underline">
+            {displayName}
+          </Link>
+          {isCurrentUser && (
+            <span className="ml-2 text-xs bg-muted text-muted-foreground rounded-full px-2 py-0.5">
+              You
+            </span>
+          )}
+        </div>
+      </div>
+      <Button 
+        variant="outline" 
+        size="sm" 
+        className="text-red-600"
+        onClick={onRemove}
+        disabled={isCurrentUser}
+      >
+        <XCircle className="h-4 w-4 mr-1" />
+        Remove
+      </Button>
+    </div>
+  );
+}

--- a/src/components/groups/MemberManagement.tsx
+++ b/src/components/groups/MemberManagement.tsx
@@ -32,7 +32,7 @@ export function MemberManagement({ communityId, isModerator }: MemberManagementP
       const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
       
       const events = await nostr.query([{ 
-        kinds: [14551],
+        kinds: [4552],
         "#a": [communityId],
         limit: 50,
       }], { signal });

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -14,7 +14,10 @@ import { Label } from "@/components/ui/label";
 import { useAuthor } from "@/hooks/useAuthor";
 import { CreatePostForm } from "@/components/groups/CreatePostForm";
 import { PostList } from "@/components/groups/PostList";
-import { Users, Settings, Info, MessageSquare, CheckCircle } from "lucide-react";
+import { JoinRequestButton } from "@/components/groups/JoinRequestButton";
+import { MemberManagement } from "@/components/groups/MemberManagement";
+import { ApprovedMembersList } from "@/components/groups/ApprovedMembersList";
+import { Users, Settings, Info, MessageSquare, CheckCircle, UserPlus } from "lucide-react";
 import { parseNostrAddress } from "@/lib/nostr-utils";
 
 export default function GroupDetail() {
@@ -95,8 +98,11 @@ export default function GroupDetail() {
           </Link>
           <h1 className="text-3xl font-bold">{name}</h1>
         </div>
-        <div className="ml-auto">
-          <LoginArea />
+        <div className="flex items-center gap-4">
+          <JoinRequestButton communityId={groupId || ''} />
+          <div className="ml-auto">
+            <LoginArea />
+          </div>
         </div>
       </div>
       
@@ -119,16 +125,15 @@ export default function GroupDetail() {
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center">
-                <Users className="h-5 w-5 mr-2" />
-                Moderators
+                <UserPlus className="h-5 w-5 mr-2" />
+                Join this group
               </CardTitle>
+              <CardDescription>
+                Request to join this community to participate in discussions
+              </CardDescription>
             </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {moderatorTags.map((tag) => (
-                  <ModeratorItem key={tag[1]} pubkey={tag[1]} />
-                ))}
-              </div>
+            <CardContent className="flex justify-center py-4">
+              <JoinRequestButton communityId={groupId || ''} />
             </CardContent>
             {isModerator && (
               <CardFooter>
@@ -151,6 +156,10 @@ export default function GroupDetail() {
           <TabsTrigger value="posts">
             <MessageSquare className="h-4 w-4 mr-2" />
             Posts
+          </TabsTrigger>
+          <TabsTrigger value="members">
+            <Users className="h-4 w-4 mr-2" />
+            Members
           </TabsTrigger>
           <TabsTrigger value="about">
             <Info className="h-4 w-4 mr-2" />
@@ -178,6 +187,32 @@ export default function GroupDetail() {
           </div>
           
           <PostList communityId={groupId || ''} showOnlyApproved={showOnlyApproved} />
+        </TabsContent>
+        
+        <TabsContent value="members" className="space-y-6">
+          {isModerator && (
+            <MemberManagement communityId={groupId || ''} isModerator={isModerator} />
+          )}
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <Users className="h-5 w-5 mr-2" />
+                  Moderators
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-4">
+                  {moderatorTags.map((tag) => (
+                    <ModeratorItem key={tag[1]} pubkey={tag[1]} />
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+            
+            <ApprovedMembersList communityId={groupId || ''} />
+          </div>
         </TabsContent>
         
         <TabsContent value="about">


### PR DESCRIPTION
Adds the ability to request and join a group, and for Moderators to review and approve members. 

Also, approved users' posts are automatically displayed in the approved feed.

Fixes #1 

![Screenshot from 2025-05-20 12-42-01](https://github.com/user-attachments/assets/282d5b28-f799-4aec-8947-2e3a4f251f38)

![Screenshot from 2025-05-20 12-40-20](https://github.com/user-attachments/assets/1dd22ee8-5623-4212-839f-3254e8f33de2)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a "Members" tab to group pages, allowing users to view approved members and moderators.
	- Introduced the ability for users to request to join a group, including an optional join reason.
	- Moderators can now approve or decline join requests and manage group membership directly from the interface.
	- Posts authored by approved members or moderators are now automatically marked as "Auto-approved" in the post list.

- **UI Improvements**
	- Reorganized group detail pages for clearer separation of posts, about, and member management.
	- Enhanced member and moderator listing with profile images, display names, and improved visual feedback for actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->