### PR TITLE
Moderation 101

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -4,6 +4,7 @@ import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import Groups from "./pages/Groups";
 import GroupDetail from "./pages/GroupDetail";
+import GroupSettings from "./pages/GroupSettings";
 import CreateGroup from "./pages/CreateGroup";
 import Profile from "./pages/Profile";
 
@@ -14,6 +15,7 @@ export function AppRouter() {
         <Route path="/" element={<Index />} />
         <Route path="/groups" element={<Groups />} />
         <Route path="/group/:groupId" element={<GroupDetail />} />
+        <Route path="/group/:groupId/settings" element={<GroupSettings />} />
         <Route path="/create-group" element={<CreateGroup />} />
         <Route path="/profile/:pubkey" element={<Profile />} />
         {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/groups/JoinRequestButton.tsx
+++ b/src/components/groups/JoinRequestButton.tsx
@@ -11,9 +11,10 @@ import { UserPlus, CheckCircle, Clock } from "lucide-react";
 
 interface JoinRequestButtonProps {
   communityId: string;
+  isModerator?: boolean;
 }
 
-export function JoinRequestButton({ communityId }: JoinRequestButtonProps) {
+export function JoinRequestButton({ communityId, isModerator = false }: JoinRequestButtonProps) {
   const [open, setOpen] = useState(false);
   const [joinReason, setJoinReason] = useState("");
   const { user } = useCurrentUser();
@@ -99,6 +100,11 @@ export function JoinRequestButton({ communityId }: JoinRequestButtonProps) {
       toast.error("Failed to send join request. Please try again.");
     }
   };
+
+  // If the user is a moderator, don't show the join button at all
+  if (isModerator) {
+    return null;
+  }
 
   if (!user) {
     return (

--- a/src/components/groups/JoinRequestButton.tsx
+++ b/src/components/groups/JoinRequestButton.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { UserPlus, CheckCircle, Clock } from "lucide-react";
+import { UserPlus, CheckCircle, Clock, XCircle } from "lucide-react";
 
 interface JoinRequestButtonProps {
   communityId: string;

--- a/src/components/groups/JoinRequestButton.tsx
+++ b/src/components/groups/JoinRequestButton.tsx
@@ -67,7 +67,7 @@ export function JoinRequestButton({ communityId, isModerator = false }: JoinRequ
       
       const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
       const events = await nostr.query([{ 
-        kinds: [4551], 
+        kinds: [14551], 
         "#a": [communityId],
         "#p": [user.pubkey]
       }], { signal });

--- a/src/components/groups/MemberManagement.tsx
+++ b/src/components/groups/MemberManagement.tsx
@@ -191,10 +191,29 @@ export function MemberManagement({ communityId, isModerator }: MemberManagementP
         content: "",
       });
       
+      // Add the removed user to the declined list (kind 14551)
+      // We'll create a generic event ID since we don't have a specific request event
+      const removalEventId = `removal:${pubkey}:${Date.now()}`;
+      
+      await publishEvent({
+        kind: 14551,
+        tags: [
+          ["a", communityId],
+          ["e", removalEventId], // Using a generated event ID
+          ["p", pubkey], // The pubkey of the removed user
+          ["k", "14550"] // Indicating this was a removal from the approved list
+        ],
+        content: JSON.stringify({
+          reason: "Removed from group by moderator",
+          timestamp: Date.now()
+        }),
+      });
+      
       toast.success("Member removed successfully!");
       
       // Refetch data
       refetchMembers();
+      refetchDeclined();
     } catch (error) {
       console.error("Error removing member:", error);
       toast.error("Failed to remove member. Please try again.");

--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -171,7 +171,7 @@ export function PostList({ communityId, showOnlyApproved = false }: PostListProp
     .map(tag => tag[1]) || [];
     
   // Check if current user is a moderator
-  const isUserModerator = user && moderators.includes(user.pubkey);
+  const isUserModerator = Boolean(user && moderators.includes(user.pubkey));
   
   // Debug logging
   console.log('Current user:', user?.pubkey);
@@ -338,32 +338,6 @@ function PostItem({ post, communityId, isApproved, isModerator }: PostItemProps)
   const metadata = author.data?.metadata;
   const displayName = metadata?.name || post.pubkey.slice(0, 8);
   const profileImage = metadata?.picture;
-  
-  // Parse the community ID to get the pubkey and identifier
-  const parsedCommunityId = communityId.includes(':') 
-    ? parseNostrAddress(communityId)
-    : null;
-  
-  // We'll use the community ID directly to check if the user is a moderator
-  // This is more reliable than trying to parse and query again
-  
-  // Check if user is a moderator (passed from parent component)
-  const { data: communityEvent } = useQuery({
-    queryKey: ["community-details-for-post", communityId],
-    queryFn: async (c) => {
-      if (!parsedCommunityId) return null;
-      
-      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
-      const events = await nostr.query([{ 
-        kinds: [34550],
-        authors: [parsedCommunityId.pubkey],
-        "#d": [parsedCommunityId.identifier],
-      }], { signal });
-      
-      return events[0] || null;
-    },
-    enabled: !!nostr && !!parsedCommunityId,
-  });
   
   // isModerator is now passed as a prop, so we don't need to check again
   

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -227,9 +227,15 @@ export default function GroupDetail() {
               </CardHeader>
               <CardContent>
                 <div className="space-y-4">
-                  {moderatorTags.map((tag) => (
-                    <ModeratorItem key={tag[1]} pubkey={tag[1]} />
-                  ))}
+                  {/* Display the group owner first */}
+                  <ModeratorItem key={community.pubkey} pubkey={community.pubkey} isCreator />
+                  
+                  {/* Display moderators who are not the owner */}
+                  {moderatorTags
+                    .filter(tag => tag[1] !== community.pubkey) // Filter out the owner if they're also listed as a moderator
+                    .map((tag) => (
+                      <ModeratorItem key={tag[1]} pubkey={tag[1]} />
+                    ))}
                 </div>
               </CardContent>
             </Card>

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -99,7 +99,7 @@ export default function GroupDetail() {
           <h1 className="text-3xl font-bold">{name}</h1>
         </div>
         <div className="flex items-center gap-4">
-          <JoinRequestButton communityId={groupId || ''} />
+          <JoinRequestButton communityId={groupId || ''} isModerator={isModerator} />
           <div className="ml-auto">
             <LoginArea />
           </div>
@@ -122,30 +122,42 @@ export default function GroupDetail() {
         </div>
         
         <div>
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center">
-                <UserPlus className="h-5 w-5 mr-2" />
-                Join this group
-              </CardTitle>
-              <CardDescription>
-                Request to join this community to participate in discussions
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="flex justify-center py-4">
-              <JoinRequestButton communityId={groupId || ''} />
-            </CardContent>
-            {isModerator && (
-              <CardFooter>
+          {isModerator ? (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <Settings className="h-5 w-5 mr-2" />
+                  Moderator Controls
+                </CardTitle>
+                <CardDescription>
+                  You are a moderator of this community
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex justify-center py-4">
                 <Button asChild variant="outline" className="w-full">
                   <Link to={`/group/${encodeURIComponent(groupId || '')}/settings`}>
                     <Settings className="h-4 w-4 mr-2" />
                     Manage Community
                   </Link>
                 </Button>
-              </CardFooter>
-            )}
-          </Card>
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <UserPlus className="h-5 w-5 mr-2" />
+                  Join this group
+                </CardTitle>
+                <CardDescription>
+                  Request to join this community to participate in discussions
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex justify-center py-4">
+                <JoinRequestButton communityId={groupId || ''} isModerator={isModerator} />
+              </CardContent>
+            </Card>
+          )}
         </div>
       </div>
       

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -54,10 +54,19 @@ export default function GroupDetail() {
     enabled: !!nostr && !!parsedId,
   });
   
+  // Check if user is the owner (the signer of the event)
+  const isOwner = user && community && user.pubkey === community.pubkey;
+  
   // Check if user is a moderator
-  const isModerator = user && community?.tags
+  const isModerator = isOwner || (user && community?.tags
     .filter(tag => tag[0] === "p" && tag[3] === "moderator")
-    .some(tag => tag[1] === user.pubkey);
+    .some(tag => tag[1] === user.pubkey));
+    
+  // Debug logging
+  console.log("Current user pubkey:", user?.pubkey);
+  console.log("Community creator pubkey:", community?.pubkey);
+  console.log("Is owner:", isOwner);
+  console.log("Is moderator:", isModerator);
   
   // Extract community data from tags
   const nameTag = community?.tags.find(tag => tag[0] === "name");
@@ -127,10 +136,12 @@ export default function GroupDetail() {
               <CardHeader>
                 <CardTitle className="flex items-center">
                   <Settings className="h-5 w-5 mr-2" />
-                  Moderator Controls
+                  {isOwner ? "Owner Controls" : "Moderator Controls"}
                 </CardTitle>
                 <CardDescription>
-                  You are a moderator of this community
+                  {isOwner 
+                    ? "You are the owner of this community" 
+                    : "You are a moderator of this community"}
                 </CardDescription>
               </CardHeader>
               <CardContent className="flex justify-center py-4">
@@ -211,7 +222,7 @@ export default function GroupDetail() {
               <CardHeader>
                 <CardTitle className="flex items-center">
                   <Users className="h-5 w-5 mr-2" />
-                  Moderators
+                  Group Owner & Moderators
                 </CardTitle>
               </CardHeader>
               <CardContent>
@@ -271,7 +282,15 @@ function ModeratorItem({ pubkey, isCreator = false }: { pubkey: string; isCreato
         </Avatar>
         <div>
           <p className="font-medium">{displayName}</p>
-          {isCreator && <p className="text-xs text-muted-foreground">Creator</p>}
+          {isCreator ? (
+            <span className="text-xs bg-purple-100 text-purple-600 rounded-full px-2 py-0.5">
+              Group Owner
+            </span>
+          ) : (
+            <span className="text-xs bg-blue-100 text-blue-600 rounded-full px-2 py-0.5">
+              Moderator
+            </span>
+          )}
         </div>
       </div>
     </Link>

--- a/src/pages/GroupSettings.tsx
+++ b/src/pages/GroupSettings.tsx
@@ -1,0 +1,513 @@
+import { useState, useEffect } from "react";
+import { useParams, Link, useNavigate } from "react-router-dom";
+import { useNostr } from "@/hooks/useNostr";
+import { useNostrPublish } from "@/hooks/useNostrPublish";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAuthor } from "@/hooks/useAuthor";
+import { toast } from "sonner";
+import { ArrowLeft, Save, UserPlus, Users, Shield, Trash2 } from "lucide-react";
+import { parseNostrAddress } from "@/lib/nostr-utils";
+import { NostrEvent } from "@nostrify/nostrify";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+export default function GroupSettings() {
+  const { groupId } = useParams<{ groupId: string }>();
+  const { nostr } = useNostr();
+  const { user } = useCurrentUser();
+  const { mutateAsync: publishEvent } = useNostrPublish();
+  const navigate = useNavigate();
+  const [parsedId, setParsedId] = useState<{ kind: number; pubkey: string; identifier: string } | null>(null);
+  
+  // Form state
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [imageUrl, setImageUrl] = useState("");
+  const [moderators, setModerators] = useState<string[]>([]);
+  const [isRemoveModDialogOpen, setIsRemoveModDialogOpen] = useState<string | null>(null);
+  
+  useEffect(() => {
+    if (groupId) {
+      const parsed = parseNostrAddress(decodeURIComponent(groupId));
+      if (parsed) {
+        setParsedId(parsed);
+      }
+    }
+  }, [groupId]);
+  
+  // Query for community details
+  const { data: community, isLoading: isLoadingCommunity } = useQuery({
+    queryKey: ["community-settings", parsedId?.pubkey, parsedId?.identifier],
+    queryFn: async (c) => {
+      if (!parsedId) throw new Error("Invalid community ID");
+      
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      const events = await nostr.query([{ 
+        kinds: [34550], 
+        authors: [parsedId.pubkey],
+        "#d": [parsedId.identifier]
+      }], { signal });
+      
+      if (events.length === 0) throw new Error("Community not found");
+      return events[0];
+    },
+    enabled: !!nostr && !!parsedId,
+    onSuccess: (data) => {
+      // Initialize form with current values
+      const nameTag = data.tags.find(tag => tag[0] === "name");
+      const descriptionTag = data.tags.find(tag => tag[0] === "description");
+      const imageTag = data.tags.find(tag => tag[0] === "image");
+      const modTags = data.tags.filter(tag => tag[0] === "p" && tag[3] === "moderator");
+      
+      setName(nameTag ? nameTag[1] : "");
+      setDescription(descriptionTag ? descriptionTag[1] : "");
+      setImageUrl(imageTag ? imageTag[1] : "");
+      setModerators(modTags.map(tag => tag[1]));
+    }
+  });
+  
+  // Query for approved members
+  const { data: approvedMembersEvents, isLoading: isLoadingMembers } = useQuery({
+    queryKey: ["approved-members-settings", groupId],
+    queryFn: async (c) => {
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      
+      const events = await nostr.query([{ 
+        kinds: [14550],
+        "#a": [groupId || ""],
+        limit: 50,
+      }], { signal });
+      
+      return events;
+    },
+    enabled: !!nostr && !!groupId,
+  });
+  
+  // Extract all approved member pubkeys from the events
+  const approvedMembers = approvedMembersEvents?.flatMap(event => 
+    event.tags.filter(tag => tag[0] === "p").map(tag => tag[1])
+  ) || [];
+  
+  // Remove duplicates
+  const uniqueApprovedMembers = [...new Set(approvedMembers)];
+  
+  // Check if user is a moderator
+  const isModerator = user && moderators.includes(user.pubkey);
+  
+  // Check if user is the creator (first moderator)
+  const isCreator = user && community && community.pubkey === user.pubkey;
+  
+  // Handle form submission
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!user) {
+      toast.error("You must be logged in to update community settings");
+      return;
+    }
+    
+    if (!parsedId) {
+      toast.error("Invalid community ID");
+      return;
+    }
+    
+    if (!isModerator && !isCreator) {
+      toast.error("You must be a moderator to update community settings");
+      return;
+    }
+    
+    try {
+      // Build tags array
+      const tags = [
+        ["d", parsedId.identifier],
+        ["name", name],
+        ["description", description],
+      ];
+      
+      if (imageUrl) {
+        tags.push(["image", imageUrl]);
+      }
+      
+      // Add moderator tags
+      moderators.forEach(mod => {
+        tags.push(["p", mod, "", "moderator"]);
+      });
+      
+      // Create community update event (kind 34550)
+      await publishEvent({
+        kind: 34550,
+        tags,
+        content: "",
+      });
+      
+      toast.success("Community settings updated successfully!");
+      
+      // Navigate back to community page
+      navigate(`/group/${encodeURIComponent(groupId || "")}`);
+    } catch (error) {
+      console.error("Error updating community settings:", error);
+      toast.error("Failed to update community settings. Please try again.");
+    }
+  };
+  
+  const handleAddModerator = async (pubkey: string) => {
+    if (!moderators.includes(pubkey)) {
+      setModerators([...moderators, pubkey]);
+      toast.success("Moderator added. Save changes to apply.");
+    }
+  };
+  
+  const handleRemoveModerator = (pubkey: string) => {
+    // Don't allow removing the creator
+    if (community && community.pubkey === pubkey) {
+      toast.error("Cannot remove the community creator");
+      return;
+    }
+    
+    setModerators(moderators.filter(mod => mod !== pubkey));
+    setIsRemoveModDialogOpen(null);
+    toast.success("Moderator removed. Save changes to apply.");
+  };
+  
+  if (isLoadingCommunity) {
+    return (
+      <div className="container mx-auto p-4">
+        <h1 className="text-2xl font-bold mb-4">Loading community settings...</h1>
+      </div>
+    );
+  }
+  
+  if (!community) {
+    return (
+      <div className="container mx-auto p-4">
+        <h1 className="text-2xl font-bold mb-4">Community not found</h1>
+        <p>The community you're looking for doesn't exist or has been deleted.</p>
+        <Button asChild className="mt-4">
+          <Link to="/groups">Back to Communities</Link>
+        </Button>
+      </div>
+    );
+  }
+  
+  if (!isModerator && !isCreator) {
+    return (
+      <div className="container mx-auto p-4">
+        <h1 className="text-2xl font-bold mb-4">Access Denied</h1>
+        <p>You must be a moderator to access community settings.</p>
+        <Button asChild className="mt-4">
+          <Link to={`/group/${encodeURIComponent(groupId || "")}`}>Back to Community</Link>
+        </Button>
+      </div>
+    );
+  }
+  
+  return (
+    <div className="container mx-auto p-4">
+      <div className="flex items-center mb-6">
+        <Button variant="ghost" size="sm" asChild className="mr-2">
+          <Link to={`/group/${encodeURIComponent(groupId || "")}`}>
+            <ArrowLeft className="h-4 w-4 mr-1" />
+            Back to Community
+          </Link>
+        </Button>
+        <h1 className="text-2xl font-bold">Community Settings</h1>
+      </div>
+      
+      <Tabs defaultValue="general" className="w-full">
+        <TabsList className="mb-6">
+          <TabsTrigger value="general">General</TabsTrigger>
+          <TabsTrigger value="moderators">Moderators</TabsTrigger>
+        </TabsList>
+        
+        <form onSubmit={handleSubmit}>
+          <TabsContent value="general">
+            <Card>
+              <CardHeader>
+                <CardTitle>General Settings</CardTitle>
+                <CardDescription>
+                  Update your community's basic information
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="name">Community Name</Label>
+                  <Input 
+                    id="name" 
+                    value={name} 
+                    onChange={(e) => setName(e.target.value)} 
+                    placeholder="Enter community name"
+                    required
+                  />
+                </div>
+                
+                <div className="space-y-2">
+                  <Label htmlFor="description">Description</Label>
+                  <Textarea 
+                    id="description" 
+                    value={description} 
+                    onChange={(e) => setDescription(e.target.value)} 
+                    placeholder="Enter community description"
+                    rows={4}
+                  />
+                </div>
+                
+                <div className="space-y-2">
+                  <Label htmlFor="image">Image URL</Label>
+                  <Input 
+                    id="image" 
+                    value={imageUrl} 
+                    onChange={(e) => setImageUrl(e.target.value)} 
+                    placeholder="Enter image URL"
+                  />
+                  
+                  {imageUrl && (
+                    <div className="mt-2 rounded-md overflow-hidden border w-full max-w-xs">
+                      <img 
+                        src={imageUrl} 
+                        alt="Community preview" 
+                        className="w-full h-auto"
+                        onError={(e) => {
+                          e.currentTarget.src = "https://placehold.co/400x200?text=Invalid+Image";
+                        }}
+                      />
+                    </div>
+                  )}
+                </div>
+              </CardContent>
+              <CardFooter>
+                <Button type="submit" className="ml-auto">
+                  <Save className="h-4 w-4 mr-2" />
+                  Save Changes
+                </Button>
+              </CardFooter>
+            </Card>
+          </TabsContent>
+          
+          <TabsContent value="moderators">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center">
+                    <Shield className="h-5 w-5 mr-2" />
+                    Current Moderators
+                  </CardTitle>
+                  <CardDescription>
+                    Manage who can moderate this community
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-4">
+                    {moderators.length === 0 ? (
+                      <p className="text-muted-foreground">No moderators yet</p>
+                    ) : (
+                      moderators.map((pubkey) => (
+                        <ModeratorItem 
+                          key={pubkey} 
+                          pubkey={pubkey} 
+                          isCreator={community.pubkey === pubkey}
+                          onRemove={() => setIsRemoveModDialogOpen(pubkey)}
+                        />
+                      ))
+                    )}
+                  </div>
+                </CardContent>
+                <CardFooter>
+                  <Button type="submit" className="ml-auto">
+                    <Save className="h-4 w-4 mr-2" />
+                    Save Changes
+                  </Button>
+                </CardFooter>
+              </Card>
+              
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center">
+                    <Users className="h-5 w-5 mr-2" />
+                    Community Members
+                  </CardTitle>
+                  <CardDescription>
+                    Promote members to moderators
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {isLoadingMembers ? (
+                    <div className="space-y-4">
+                      {[1, 2, 3].map((i) => (
+                        <div key={i} className="flex items-center justify-between p-2 border rounded-md">
+                          <div className="flex items-center gap-3">
+                            <Skeleton className="h-10 w-10 rounded-full" />
+                            <div>
+                              <Skeleton className="h-4 w-32 mb-1" />
+                            </div>
+                          </div>
+                          <Skeleton className="h-9 w-20" />
+                        </div>
+                      ))}
+                    </div>
+                  ) : uniqueApprovedMembers.length === 0 ? (
+                    <div className="text-center py-8 text-muted-foreground">
+                      <Users className="h-12 w-12 mx-auto mb-3 opacity-20" />
+                      <p>No approved members yet</p>
+                    </div>
+                  ) : (
+                    <div className="space-y-4">
+                      {uniqueApprovedMembers
+                        .filter(pubkey => !moderators.includes(pubkey)) // Only show non-moderators
+                        .map((pubkey) => (
+                          <MemberItem 
+                            key={pubkey} 
+                            pubkey={pubkey} 
+                            onPromote={() => handleAddModerator(pubkey)} 
+                          />
+                        ))}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </div>
+          </TabsContent>
+        </form>
+      </Tabs>
+      
+      <AlertDialog open={!!isRemoveModDialogOpen} onOpenChange={() => setIsRemoveModDialogOpen(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove Moderator</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to remove this moderator? They will no longer be able to manage this community.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction 
+              onClick={() => isRemoveModDialogOpen && handleRemoveModerator(isRemoveModDialogOpen)}
+              className="bg-red-600 hover:bg-red-700"
+            >
+              Remove Moderator
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+interface ModeratorItemProps {
+  pubkey: string;
+  isCreator?: boolean;
+  onRemove: () => void;
+}
+
+function ModeratorItem({ pubkey, isCreator = false, onRemove }: ModeratorItemProps) {
+  const author = useAuthor(pubkey);
+  const { user } = useCurrentUser();
+  const metadata = author.data?.metadata;
+  
+  const displayName = metadata?.name || pubkey.slice(0, 8);
+  const profileImage = metadata?.picture;
+  const isCurrentUser = user?.pubkey === pubkey;
+  
+  return (
+    <div className="flex items-center justify-between p-3 border rounded-md">
+      <div className="flex items-center gap-3">
+        <Link to={`/profile/${pubkey}`}>
+          <Avatar>
+            <AvatarImage src={profileImage} />
+            <AvatarFallback>{displayName.slice(0, 2).toUpperCase()}</AvatarFallback>
+          </Avatar>
+        </Link>
+        <div>
+          <Link to={`/profile/${pubkey}`} className="font-medium hover:underline">
+            {displayName}
+          </Link>
+          <div className="flex items-center gap-2">
+            {isCreator && (
+              <span className="text-xs bg-blue-100 text-blue-600 rounded-full px-2 py-0.5">
+                Creator
+              </span>
+            )}
+            {isCurrentUser && (
+              <span className="text-xs bg-muted text-muted-foreground rounded-full px-2 py-0.5">
+                You
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+      {!isCreator && (
+        <Button 
+          variant="outline" 
+          size="sm" 
+          className="text-red-600"
+          onClick={onRemove}
+        >
+          <Trash2 className="h-4 w-4 mr-1" />
+          Remove
+        </Button>
+      )}
+    </div>
+  );
+}
+
+interface MemberItemProps {
+  pubkey: string;
+  onPromote: () => void;
+}
+
+function MemberItem({ pubkey, onPromote }: MemberItemProps) {
+  const author = useAuthor(pubkey);
+  const { user } = useCurrentUser();
+  const metadata = author.data?.metadata;
+  
+  const displayName = metadata?.name || pubkey.slice(0, 8);
+  const profileImage = metadata?.picture;
+  const isCurrentUser = user?.pubkey === pubkey;
+  
+  return (
+    <div className="flex items-center justify-between p-3 border rounded-md">
+      <div className="flex items-center gap-3">
+        <Link to={`/profile/${pubkey}`}>
+          <Avatar>
+            <AvatarImage src={profileImage} />
+            <AvatarFallback>{displayName.slice(0, 2).toUpperCase()}</AvatarFallback>
+          </Avatar>
+        </Link>
+        <div>
+          <Link to={`/profile/${pubkey}`} className="font-medium hover:underline">
+            {displayName}
+          </Link>
+          {isCurrentUser && (
+            <span className="ml-2 text-xs bg-muted text-muted-foreground rounded-full px-2 py-0.5">
+              You
+            </span>
+          )}
+        </div>
+      </div>
+      <Button 
+        variant="outline" 
+        size="sm"
+        onClick={onPromote}
+      >
+        <UserPlus className="h-4 w-4 mr-1" />
+        Make Moderator
+      </Button>
+    </div>
+  );
+}

--- a/src/pages/GroupSettings.tsx
+++ b/src/pages/GroupSettings.tsx
@@ -499,10 +499,6 @@ export default function GroupSettings() {
                   </div>
                 </CardContent>
                 <CardFooter>
-                  <Button type="submit" className="ml-auto">
-                    <Save className="h-4 w-4 mr-2" />
-                    Save Changes
-                  </Button>
                 </CardFooter>
               </Card>
               

--- a/src/pages/GroupSettings.tsx
+++ b/src/pages/GroupSettings.tsx
@@ -687,6 +687,7 @@ function MemberItem({ pubkey, onPromote, isOwner }: MemberItemProps) {
         onClick={onPromote}
         disabled={!isOwner}
         title={!isOwner ? "Only the group owner can add moderators" : "This will immediately update the group"}
+        type="button"
       >
         <UserPlus className="h-4 w-4 mr-1" />
         Make Moderator

--- a/typescript_errors.txt
+++ b/typescript_errors.txt
@@ -1,0 +1,8 @@
+src/components/groups/JoinRequestButton.tsx(149,10): error TS2304: Cannot find name 'XCircle'.
+src/components/groups/PostList.tsx(307,11): error TS2322: Type 'boolean | undefined' is not assignable to type 'boolean'.
+  Type 'undefined' is not assignable to type 'boolean'.
+src/components/groups/PostList.tsx(357,28): error TS2304: Cannot find name 'nostr'.
+src/components/groups/PostList.tsx(365,16): error TS2304: Cannot find name 'nostr'.
+src/pages/GroupSettings.tsx(94,7): error TS2448: Block-scoped variable 'community' used before its declaration.
+src/pages/GroupSettings.tsx(609,29): error TS2322: Type 'boolean | undefined' is not assignable to type 'boolean'.
+  Type 'undefined' is not assignable to type 'boolean'.


### PR DESCRIPTION
- Fixes #14 
- Fixes #19  
- Fixes #15 
- Fixes #13 (mostly, could use improvement)

![Screenshot from 2025-05-20 14-34-10](https://github.com/user-attachments/assets/24f22536-9463-4c95-b28c-5cefd6d81444)

![Screenshot from 2025-05-20 12-54-45](https://github.com/user-attachments/assets/4062a0ce-6c19-4ea4-963e-4254cc330c23)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated Group Settings page for managing community details and moderators, accessible to group owners and moderators.
  - Added support for declining, approving, and managing declined users in group member management, including a new "Declined" tab.
  - Enabled moderators to remove posts, with removed posts no longer displayed in group feeds.
  - Enhanced moderator and owner role distinction, with improved UI labels and controls reflecting user roles.
  - Added a new route for Group Settings accessible via group-specific URLs.

- **Bug Fixes**
  - Updated join request button behavior to hide for moderators and display declined status for users as appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->