### PR TITLE
Reply Moderation & Post Approval UI

### DIFF
--- a/src/components/groups/PendingPostsList.tsx
+++ b/src/components/groups/PendingPostsList.tsx
@@ -1,0 +1,120 @@
+import { useNostr } from "@/hooks/useNostr";
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PostList } from "./PostList";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { AlertCircle, CheckCircle } from "lucide-react";
+
+interface PendingPostsListProps {
+  communityId: string;
+}
+
+export function PendingPostsList({ communityId }: PendingPostsListProps) {
+  const { nostr } = useNostr();
+  
+  // Query for pending posts count - using the same query key as in GroupDetail.tsx
+  const { data: pendingPostsCount = 0, isLoading } = useQuery({
+    queryKey: ["pending-posts-count", communityId],
+    queryFn: async (c) => {
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      
+      // Get posts that tag the community
+      const posts = await nostr.query([{ 
+        kinds: [1, 11],
+        "#a": [communityId],
+        limit: 100,
+      }], { signal });
+      
+      // Get approval events
+      const approvals = await nostr.query([{ 
+        kinds: [4550],
+        "#a": [communityId],
+        limit: 100,
+      }], { signal });
+      
+      // Get removal events
+      const removals = await nostr.query([{ 
+        kinds: [4551],
+        "#a": [communityId],
+        limit: 100,
+      }], { signal });
+      
+      // Extract the approved post IDs
+      const approvedPostIds = approvals.map(approval => {
+        const eventTag = approval.tags.find(tag => tag[0] === "e");
+        return eventTag ? eventTag[1] : null;
+      }).filter((id): id is string => id !== null);
+      
+      // Extract the removed post IDs
+      const removedPostIds = removals.map(removal => {
+        const eventTag = removal.tags.find(tag => tag[0] === "e");
+        return eventTag ? eventTag[1] : null;
+      }).filter((id): id is string => id !== null);
+      
+      // Filter out posts that are already approved or removed
+      const pendingPosts = posts.filter(post => 
+        !approvedPostIds.includes(post.id) && 
+        !removedPostIds.includes(post.id)
+      );
+      
+      return pendingPosts.length;
+    },
+    enabled: !!nostr && !!communityId,
+    staleTime: 30000, // Cache for 30 seconds to reduce duplicate queries
+  });
+  
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-64 mb-4" />
+        {[1, 2].map((i) => (
+          <Card key={i}>
+            <CardContent className="p-6">
+              <Skeleton className="h-4 w-full mb-2" />
+              <Skeleton className="h-4 w-full mb-2" />
+              <Skeleton className="h-4 w-2/3" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+  
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold">Pending Posts</h2>
+        <div className="bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200 px-3 py-1 rounded-full text-sm font-medium">
+          {pendingPostsCount} pending
+        </div>
+      </div>
+      
+      {!pendingPostsCount || pendingPostsCount === 0 ? (
+        <Alert className="bg-green-50 border-green-200 text-green-800 dark:bg-green-950 dark:border-green-800 dark:text-green-200">
+          <CheckCircle className="h-4 w-4" />
+          <AlertTitle>No pending posts</AlertTitle>
+          <AlertDescription>
+            All posts have been reviewed. There are currently no posts waiting for approval in this community.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <>
+          <Alert className="bg-amber-50 border-amber-200 text-amber-800 dark:bg-amber-950 dark:border-amber-800 dark:text-amber-200">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Pending Approval</AlertTitle>
+            <AlertDescription>
+              These posts are waiting for moderator approval before they will be visible to all community members.
+            </AlertDescription>
+          </Alert>
+          
+          <PostList 
+            communityId={communityId} 
+            showOnlyApproved={false} 
+            pendingOnly={true}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/groups/PendingPostsList.tsx
+++ b/src/components/groups/PendingPostsList.tsx
@@ -3,8 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PostList } from "./PostList";
+import { PendingRepliesList } from "./PendingRepliesList";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AlertCircle, CheckCircle } from "lucide-react";
+import { Separator } from "@/components/ui/separator";
 
 interface PendingPostsListProps {
   communityId: string;
@@ -62,7 +64,8 @@ export function PendingPostsList({ communityId }: PendingPostsListProps) {
             <AlertCircle className="h-4 w-4" />
             <AlertTitle>Pending Approval</AlertTitle>
             <AlertDescription>
-              These posts are waiting for moderator approval before they will be visible to all community members.
+              These posts are from users who are not approved members, moderators, or the group owner.
+              They need your approval before they will be visible to all community members.
             </AlertDescription>
           </Alert>
           
@@ -73,6 +76,12 @@ export function PendingPostsList({ communityId }: PendingPostsListProps) {
           />
         </>
       )}
+      
+      {/* Separator between posts and replies */}
+      <Separator className="my-8" />
+      
+      {/* Pending Replies Section */}
+      <PendingRepliesList communityId={communityId} />
     </div>
   );
 }

--- a/src/components/groups/PendingPostsList.tsx
+++ b/src/components/groups/PendingPostsList.tsx
@@ -1,5 +1,5 @@
 import { useNostr } from "@/hooks/useNostr";
-import { useQuery } from "@tanstack/react-query";
+import { usePendingPostsCount } from "@/hooks/usePendingPostsCount";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PostList } from "./PostList";
@@ -15,14 +15,8 @@ interface PendingPostsListProps {
 export function PendingPostsList({ communityId }: PendingPostsListProps) {
   const { nostr } = useNostr();
   
-  // Query for pending posts count - using the same query key as in GroupDetail.tsx
-  const { data: pendingPostsCount = 0, isLoading } = useQuery({
-    queryKey: ["pending-posts-count", communityId],
-    // We're using the same query key as in GroupDetail.tsx, so we don't need to duplicate the query logic
-    // The data will be shared between components
-    enabled: !!nostr && !!communityId,
-    staleTime: 30000, // Cache for 30 seconds to reduce duplicate queries
-  });
+  // Query for pending posts count using our custom hook
+  const { data: pendingPostsCount = 0, isLoading } = usePendingPostsCount(communityId);
   
   if (isLoading) {
     return (

--- a/src/components/groups/PendingPostsList.tsx
+++ b/src/components/groups/PendingPostsList.tsx
@@ -16,50 +16,8 @@ export function PendingPostsList({ communityId }: PendingPostsListProps) {
   // Query for pending posts count - using the same query key as in GroupDetail.tsx
   const { data: pendingPostsCount = 0, isLoading } = useQuery({
     queryKey: ["pending-posts-count", communityId],
-    queryFn: async (c) => {
-      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
-      
-      // Get posts that tag the community
-      const posts = await nostr.query([{ 
-        kinds: [1, 11],
-        "#a": [communityId],
-        limit: 100,
-      }], { signal });
-      
-      // Get approval events
-      const approvals = await nostr.query([{ 
-        kinds: [4550],
-        "#a": [communityId],
-        limit: 100,
-      }], { signal });
-      
-      // Get removal events
-      const removals = await nostr.query([{ 
-        kinds: [4551],
-        "#a": [communityId],
-        limit: 100,
-      }], { signal });
-      
-      // Extract the approved post IDs
-      const approvedPostIds = approvals.map(approval => {
-        const eventTag = approval.tags.find(tag => tag[0] === "e");
-        return eventTag ? eventTag[1] : null;
-      }).filter((id): id is string => id !== null);
-      
-      // Extract the removed post IDs
-      const removedPostIds = removals.map(removal => {
-        const eventTag = removal.tags.find(tag => tag[0] === "e");
-        return eventTag ? eventTag[1] : null;
-      }).filter((id): id is string => id !== null);
-      
-      // Filter out posts that are already approved or removed
-      const pendingPosts = posts.filter(post => 
-        !approvedPostIds.includes(post.id) && 
-        !removedPostIds.includes(post.id)
-      );
-      
-      return pendingPosts.length;
-    },
+    // We're using the same query key as in GroupDetail.tsx, so we don't need to duplicate the query logic
+    // The data will be shared between components
     enabled: !!nostr && !!communityId,
     staleTime: 30000, // Cache for 30 seconds to reduce duplicate queries
   });

--- a/src/components/groups/PendingRepliesList.tsx
+++ b/src/components/groups/PendingRepliesList.tsx
@@ -1,0 +1,199 @@
+import { useState } from "react";
+import { usePendingReplies } from "@/hooks/usePendingReplies";
+import { useAuthor } from "@/hooks/useAuthor";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useNostrPublish } from "@/hooks/useNostrPublish";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { NoteContent } from "../NoteContent";
+import { Link } from "react-router-dom";
+import { CheckCircle, AlertCircle, MessageSquare, ArrowUpRight } from "lucide-react";
+import { toast } from "sonner";
+import { NostrEvent } from "@nostrify/nostrify";
+
+interface PendingRepliesListProps {
+  communityId: string;
+}
+
+export function PendingRepliesList({ communityId }: PendingRepliesListProps) {
+  const { data: pendingReplies, isLoading, refetch } = usePendingReplies(communityId);
+  
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-64 mb-4" />
+        {[1, 2].map((i) => (
+          <Card key={i}>
+            <CardContent className="p-6">
+              <Skeleton className="h-4 w-full mb-2" />
+              <Skeleton className="h-4 w-full mb-2" />
+              <Skeleton className="h-4 w-2/3" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+  
+  if (!pendingReplies || pendingReplies.length === 0) {
+    return (
+      <Alert className="bg-green-50 border-green-200 text-green-800 dark:bg-green-950 dark:border-green-800 dark:text-green-200">
+        <CheckCircle className="h-4 w-4" />
+        <AlertTitle>No pending replies</AlertTitle>
+        <AlertDescription>
+          All replies have been reviewed. There are currently no replies waiting for approval in this community.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h3 className="text-xl font-bold">Pending Replies</h3>
+        <div className="bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200 px-3 py-1 rounded-full text-sm font-medium">
+          {pendingReplies.length} pending
+        </div>
+      </div>
+      
+      <Alert className="bg-amber-50 border-amber-200 text-amber-800 dark:bg-amber-950 dark:border-amber-800 dark:text-amber-200">
+        <AlertCircle className="h-4 w-4" />
+        <AlertTitle>Pending Reply Approval</AlertTitle>
+        <AlertDescription>
+          These replies are from users who are not approved members, moderators, or the group owner. 
+          They need your approval before they will be visible to all community members.
+        </AlertDescription>
+      </Alert>
+      
+      <div className="space-y-4">
+        {pendingReplies.map((reply) => (
+          <PendingReplyItem 
+            key={reply.id} 
+            reply={reply} 
+            communityId={communityId}
+            onApproved={() => refetch()}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface PendingReplyItemProps {
+  reply: NostrEvent & {
+    parent: NostrEvent | null;
+    parentId: string;
+  };
+  communityId: string;
+  onApproved: () => void;
+}
+
+function PendingReplyItem({ reply, communityId, onApproved }: PendingReplyItemProps) {
+  const author = useAuthor(reply.pubkey);
+  const { user } = useCurrentUser();
+  const { mutateAsync: publishEvent } = useNostrPublish();
+  const parentAuthor = useAuthor(reply.parent?.pubkey || "");
+  
+  const metadata = author.data?.metadata;
+  const displayName = metadata?.name || reply.pubkey.slice(0, 8);
+  const profileImage = metadata?.picture;
+  
+  const parentMetadata = parentAuthor.data?.metadata;
+  const parentDisplayName = parentMetadata?.name || reply.parent?.pubkey?.slice(0, 8) || "Unknown";
+  
+  const handleApproveReply = async () => {
+    if (!user) {
+      toast.error("You must be logged in to approve replies");
+      return;
+    }
+    
+    try {
+      // Create approval event (kind 4550)
+      await publishEvent({
+        kind: 4550,
+        tags: [
+          ["a", communityId],
+          ["e", reply.id],
+          ["p", reply.pubkey],
+          ["k", "1111"], // Reply kind
+        ],
+        content: JSON.stringify(reply),
+      });
+      
+      toast.success("Reply approved successfully!");
+      onApproved(); // Refresh the list
+    } catch (error) {
+      console.error("Error approving reply:", error);
+      toast.error("Failed to approve reply. Please try again.");
+    }
+  };
+  
+  return (
+    <Card className="border-amber-200 dark:border-amber-800">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Link to={`/profile/${reply.pubkey}`}>
+              <Avatar className="h-8 w-8 cursor-pointer hover:opacity-80 transition-opacity">
+                <AvatarImage src={profileImage} />
+                <AvatarFallback>{displayName.slice(0, 2).toUpperCase()}</AvatarFallback>
+              </Avatar>
+            </Link>
+            <div>
+              <Link to={`/profile/${reply.pubkey}`} className="hover:underline">
+                <p className="font-semibold text-sm">{displayName}</p>
+              </Link>
+              <div className="flex items-center text-xs text-muted-foreground">
+                <span>{new Date(reply.created_at * 1000).toLocaleString()}</span>
+                <span className="ml-2 text-amber-600 dark:text-amber-400 flex items-center">
+                  <AlertCircle className="h-3 w-3 mr-1" />
+                  Pending approval
+                </span>
+              </div>
+            </div>
+          </div>
+          
+          <Button 
+            variant="outline" 
+            size="sm"
+            onClick={handleApproveReply}
+            className="text-green-600"
+          >
+            <CheckCircle className="h-4 w-4 mr-1" />
+            Approve
+          </Button>
+        </div>
+      </CardHeader>
+      
+      <CardContent>
+        {reply.parent && (
+          <div className="mb-3 p-2 bg-muted/30 rounded-md text-xs text-muted-foreground">
+            <div className="flex items-center gap-1 mb-1">
+              <MessageSquare className="h-3 w-3" />
+              <span>Replying to <span className="font-medium">{parentDisplayName}</span>:</span>
+            </div>
+            <div className="line-clamp-2">
+              {reply.parent.content.length > 100 
+                ? `${reply.parent.content.slice(0, 100)}...` 
+                : reply.parent.content}
+            </div>
+            <Link 
+              to={`/post/${reply.parentId}`} 
+              className="text-primary flex items-center gap-1 mt-1 hover:underline"
+            >
+              View original post
+              <ArrowUpRight className="h-3 w-3" />
+            </Link>
+          </div>
+        )}
+        
+        <div className="whitespace-pre-wrap break-words">
+          <NoteContent event={reply} className="text-sm" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -84,7 +84,7 @@ export function PostList({ communityId, showOnlyApproved = false, pendingOnly = 
           return null;
         }
       }).filter((post): post is NostrEvent & { 
-        approval: { id: string; pubkey: string; created_at: number; kind?: number } 
+        approval: { id: string; pubkey: string; created_at: number; kind: number } 
       } => post !== null);
       
       // Filter out replies (kind 1111)
@@ -95,7 +95,8 @@ export function PostList({ communityId, showOnlyApproved = false, pendingOnly = 
         }
         
         // Check if the approval kind is 1111
-        if (post.approval.kind === 1111) {
+        const approvalKind = post.approval.kind;
+        if (approvalKind === 1111) {
           return false;
         }
         
@@ -251,7 +252,8 @@ export function PostList({ communityId, showOnlyApproved = false, pendingOnly = 
           id: `auto-approved-${post.id}`,
           pubkey: post.pubkey,
           created_at: post.created_at,
-          autoApproved: true
+          autoApproved: true,
+          kind: post.kind
         }
       };
     }
@@ -406,7 +408,7 @@ interface PostItemProps {
       pubkey: string; 
       created_at: number;
       autoApproved?: boolean;
-      kind?: number;
+      kind: number;
     } 
   };
   communityId: string;

--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -230,8 +230,14 @@ export function PostList({ communityId, showOnlyApproved = false, pendingOnly = 
     // Show only approved posts
     filteredPosts = processedPosts.filter(post => 'approval' in post);
   } else if (pendingOnly) {
-    // Show only pending posts
-    filteredPosts = processedPosts.filter(post => !('approval' in post));
+    // Show only pending posts (not auto-approved and not manually approved)
+    filteredPosts = processedPosts.filter(post => {
+      // If it has an approval property, it's either manually approved or auto-approved
+      if ('approval' in post) {
+        return false;
+      }
+      return true;
+    });
   }
   
   // Sort by created_at (newest first)

--- a/src/hooks/useApprovedMembers.ts
+++ b/src/hooks/useApprovedMembers.ts
@@ -1,0 +1,78 @@
+import { useNostr } from "@nostrify/react";
+import { useQuery } from "@tanstack/react-query";
+import { parseNostrAddress } from "@/lib/nostr-utils";
+
+/**
+ * Hook to fetch and check approved members for a community
+ * @param communityId The community ID to check approved members for
+ */
+export function useApprovedMembers(communityId: string) {
+  const { nostr } = useNostr();
+
+  // Query for approved members list
+  const { data: approvedMembersEvents, isLoading } = useQuery({
+    queryKey: ["approved-members-list", communityId],
+    queryFn: async (c) => {
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      
+      const events = await nostr.query([{ 
+        kinds: [14550],
+        "#a": [communityId],
+        limit: 10,
+      }], { signal });
+      
+      return events;
+    },
+    enabled: !!nostr && !!communityId,
+  });
+
+  // Query for community details to get moderators
+  const { data: communityEvent } = useQuery({
+    queryKey: ["community-details", communityId],
+    queryFn: async (c) => {
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      
+      // Parse the community ID to get the pubkey and identifier
+      const parsedId = communityId.includes(':') 
+        ? parseNostrAddress(communityId)
+        : null;
+      
+      if (!parsedId) return null;
+      
+      const events = await nostr.query([{ 
+        kinds: [34550],
+        authors: [parsedId.pubkey],
+        "#d": [parsedId.identifier],
+      }], { signal });
+      
+      return events[0] || null;
+    },
+    enabled: !!nostr && !!communityId,
+  });
+
+  // Extract approved members pubkeys
+  const approvedMembers = approvedMembersEvents?.flatMap(event => 
+    event.tags.filter(tag => tag[0] === "p").map(tag => tag[1])
+  ) || [];
+
+  // Extract moderator pubkeys
+  const moderators = communityEvent?.tags
+    .filter(tag => tag[0] === "p" && tag[3] === "moderator")
+    .map(tag => tag[1]) || [];
+
+  /**
+   * Check if a user is an approved member or moderator
+   * @param pubkey The pubkey to check
+   * @returns boolean indicating if the user is approved
+   */
+  const isApprovedMember = (pubkey: string): boolean => {
+    return approvedMembers.includes(pubkey) || moderators.includes(pubkey);
+  };
+
+  return {
+    approvedMembers,
+    moderators,
+    isApprovedMember,
+    isLoading
+  };
+}

--- a/src/hooks/usePendingPostsCount.ts
+++ b/src/hooks/usePendingPostsCount.ts
@@ -1,0 +1,139 @@
+import { useNostr } from "@/hooks/useNostr";
+import { useQuery } from "@tanstack/react-query";
+import { parseNostrAddress } from "@/lib/nostr-utils";
+
+/**
+ * Hook to fetch the count of pending posts in a community
+ * @param communityId The community ID to fetch pending posts for
+ */
+export function usePendingPostsCount(communityId: string) {
+  const { nostr } = useNostr();
+
+  return useQuery({
+    queryKey: ["pending-posts-count", communityId],
+    queryFn: async (c) => {
+      if (!communityId) return 0;
+
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      
+      // Parse the community ID to get the pubkey and identifier
+      const parsedId = communityId.includes(':') 
+        ? parseNostrAddress(communityId)
+        : null;
+      
+      if (!parsedId) return 0;
+      
+      // Get posts that tag the community
+      const posts = await nostr.query([{ 
+        kinds: [1, 11],
+        "#a": [communityId],
+        limit: 100,
+      }], { signal });
+      
+      // Get approval events
+      const approvals = await nostr.query([{ 
+        kinds: [4550],
+        "#a": [communityId],
+        limit: 100,
+      }], { signal });
+      
+      // Get removal events
+      const removals = await nostr.query([{ 
+        kinds: [4551],
+        "#a": [communityId],
+        limit: 100,
+      }], { signal });
+      
+      // Get approved members list
+      const approvedMembersEvents = await nostr.query([{ 
+        kinds: [14550],
+        "#a": [communityId],
+        limit: 10,
+      }], { signal });
+      
+      // Get community details to get moderators
+      const communityEvent = await nostr.query([{ 
+        kinds: [34550],
+        authors: [parsedId.pubkey],
+        "#d": [parsedId.identifier],
+      }], { signal });
+      
+      // Extract approved members pubkeys
+      const approvedMembers = approvedMembersEvents.flatMap(event => 
+        event.tags.filter(tag => tag[0] === "p").map(tag => tag[1])
+      );
+      
+      // Extract moderator pubkeys
+      const moderators = communityEvent[0]?.tags
+        .filter(tag => tag[0] === "p" && tag[3] === "moderator")
+        .map(tag => tag[1]) || [];
+      
+      // Get the community owner (creator) pubkey
+      const communityOwnerPubkey = communityEvent[0]?.pubkey || "";
+      
+      // Extract the approved post IDs
+      const approvedPostIds = approvals.map(approval => {
+        const eventTag = approval.tags.find(tag => tag[0] === "e");
+        return eventTag ? eventTag[1] : null;
+      }).filter((id): id is string => id !== null);
+      
+      // Extract the removed post IDs
+      const removedPostIds = removals.map(removal => {
+        const eventTag = removal.tags.find(tag => tag[0] === "e");
+        return eventTag ? eventTag[1] : null;
+      }).filter((id): id is string => id !== null);
+      
+      // Filter out posts that are:
+      // 1. Already approved
+      // 2. Removed
+      // 3. Posted by the community owner (auto-approved)
+      // 4. Posted by approved members (auto-approved)
+      // 5. Posted by moderators (auto-approved)
+      // 6. Replies (kind 1111)
+      const pendingPosts = posts.filter(post => {
+        // Skip if post is a reply
+        if (post.kind === 1111) {
+          return false;
+        }
+        
+        // Skip if post is already approved
+        if (approvedPostIds.includes(post.id)) {
+          return false;
+        }
+        
+        // Skip if post is removed
+        if (removedPostIds.includes(post.id)) {
+          return false;
+        }
+        
+        // Skip if author is the community owner
+        if (post.pubkey === communityOwnerPubkey) {
+          return false;
+        }
+        
+        // Skip if author is an approved member or moderator
+        if (approvedMembers.includes(post.pubkey) || moderators.includes(post.pubkey)) {
+          return false;
+        }
+        
+        return true;
+      });
+      
+      // Debug logging
+      console.log("Pending posts count calculation:", {
+        totalPosts: posts.length,
+        approvedPostIds,
+        removedPostIds,
+        communityOwner: communityOwnerPubkey,
+        approvedMembers,
+        moderators,
+        pendingPostsLength: pendingPosts.length,
+        pendingPosts: pendingPosts.map(p => ({ id: p.id, pubkey: p.pubkey, kind: p.kind }))
+      });
+      
+      return pendingPosts.length;
+    },
+    enabled: !!nostr && !!communityId,
+    staleTime: 30000, // Cache for 30 seconds to reduce duplicate queries
+  });
+}

--- a/src/hooks/usePendingReplies.ts
+++ b/src/hooks/usePendingReplies.ts
@@ -1,0 +1,111 @@
+import { useNostr } from "@/hooks/useNostr";
+import { useQuery } from "@tanstack/react-query";
+import { NostrEvent } from "@nostrify/nostrify";
+import { useApprovedMembers } from "./useApprovedMembers";
+import { useReplyApprovals } from "./useReplyApprovals";
+
+/**
+ * Hook to fetch all pending replies in a community
+ * @param communityId The community ID to fetch pending replies for
+ */
+export function usePendingReplies(communityId: string) {
+  const { nostr } = useNostr();
+  const { approvedMembers, moderators } = useApprovedMembers(communityId);
+  const { replyApprovals } = useReplyApprovals(communityId);
+
+  return useQuery({
+    queryKey: ["pending-replies", communityId],
+    queryFn: async (c) => {
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      
+      // Get all replies in the community (kind 1111 with the community tag)
+      const replies = await nostr.query([{ 
+        kinds: [1111],
+        "#a": [communityId],
+        limit: 100,
+      }], { signal });
+      
+      // Get the community owner (creator) pubkey
+      const communityOwnerPubkey = communityEvent[0]?.pubkey || "";
+      
+      // Filter out replies that are:
+      // 1. Already approved
+      // 2. Posted by approved members (auto-approved)
+      // 3. Posted by moderators (auto-approved)
+      // 4. Posted by the community owner (auto-approved)
+      const pendingReplies = replies.filter(reply => {
+        // Skip if reply is already approved
+        if (replyApprovals.includes(reply.id)) {
+          return false;
+        }
+        
+        // Skip if author is the community owner (auto-approved)
+        if (communityOwnerPubkey && reply.pubkey === communityOwnerPubkey) {
+          return false;
+        }
+        
+        // Skip if author is an approved member or moderator (auto-approved)
+        if (approvedMembers.includes(reply.pubkey) || moderators.includes(reply.pubkey)) {
+          return false;
+        }
+        
+        // Debug logging to help diagnose issues
+        console.log("Pending reply check:", {
+          replyId: reply.id,
+          author: reply.pubkey,
+          communityOwner: communityOwnerPubkey,
+          isOwner: reply.pubkey === communityOwnerPubkey,
+          isApproved: replyApprovals.includes(reply.id),
+          isAuthorApproved: approvedMembers.includes(reply.pubkey),
+          isAuthorModerator: moderators.includes(reply.pubkey),
+          isPending: !replyApprovals.includes(reply.id) && 
+                    reply.pubkey !== communityOwnerPubkey &&
+                    !approvedMembers.includes(reply.pubkey) && 
+                    !moderators.includes(reply.pubkey)
+        });
+        
+        return true;
+      });
+      
+      // Get the parent posts/replies for context
+      const parentIds = pendingReplies
+        .map(reply => {
+          const parentTag = reply.tags.find(tag => tag[0] === "e");
+          return parentTag ? parentTag[1] : null;
+        })
+        .filter((id): id is string => id !== null);
+      
+      // Fetch parent events if there are any
+      let parentEvents: NostrEvent[] = [];
+      if (parentIds.length > 0) {
+        parentEvents = await nostr.query([{
+          ids: parentIds,
+          limit: parentIds.length
+        }], { signal });
+      }
+      
+      // Create a map of parent events for easy lookup
+      const parentMap = new Map<string, NostrEvent>();
+      parentEvents.forEach(event => {
+        parentMap.set(event.id, event);
+      });
+      
+      // Enhance pending replies with parent information
+      const enhancedPendingReplies = pendingReplies.map(reply => {
+        const parentId = reply.tags.find(tag => tag[0] === "e")?.[1] || "";
+        const parentEvent = parentMap.get(parentId);
+        
+        return {
+          ...reply,
+          parent: parentEvent || null,
+          parentId
+        };
+      });
+      
+      // Sort by created_at (newest first)
+      return enhancedPendingReplies.sort((a, b) => b.created_at - a.created_at);
+    },
+    enabled: !!nostr && !!communityId,
+    staleTime: 30000, // Cache for 30 seconds
+  });
+}

--- a/src/hooks/useReplyApprovals.ts
+++ b/src/hooks/useReplyApprovals.ts
@@ -1,0 +1,49 @@
+import { useNostr } from "@nostrify/react";
+import { useQuery } from "@tanstack/react-query";
+import { NostrEvent } from "@nostrify/nostrify";
+
+/**
+ * Hook to fetch and manage reply approvals
+ * @param communityId The community ID to check approvals for
+ */
+export function useReplyApprovals(communityId: string) {
+  const { nostr } = useNostr();
+
+  // Query for reply approval events
+  const { data: replyApprovals, isLoading } = useQuery({
+    queryKey: ["reply-approvals", communityId],
+    queryFn: async (c) => {
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      
+      // Get approval events for replies (kind 4550 with k=1111)
+      const approvals = await nostr.query([{ 
+        kinds: [4550],
+        "#a": [communityId],
+        "#k": ["1111"],
+        limit: 100,
+      }], { signal });
+      
+      // Extract the approved reply IDs
+      return approvals.map(approval => {
+        const eventTag = approval.tags.find(tag => tag[0] === "e");
+        return eventTag ? eventTag[1] : null;
+      }).filter((id): id is string => id !== null);
+    },
+    enabled: !!nostr && !!communityId,
+  });
+
+  /**
+   * Check if a reply is approved
+   * @param replyId The reply ID to check
+   * @returns boolean indicating if the reply is approved
+   */
+  const isReplyApproved = (replyId: string): boolean => {
+    return replyApprovals?.includes(replyId) || false;
+  };
+
+  return {
+    replyApprovals: replyApprovals || [],
+    isReplyApproved,
+    isLoading
+  };
+}

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useNostr } from "@/hooks/useNostr";
+import { usePendingReplies } from "@/hooks/usePendingReplies";
 import { useQuery } from "@tanstack/react-query";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { Button } from "@/components/ui/button";
@@ -167,13 +168,19 @@ export default function GroupDetail() {
     staleTime: 30000, // Cache for 30 seconds to reduce duplicate queries
   });
   
-  // Set active tab to "pending" if there are pending posts and user is a moderator
+  // Query for pending replies
+  const { data: pendingReplies = [] } = usePendingReplies(groupId || '');
+  
+  // Calculate total pending items (posts + replies)
+  const totalPendingCount = (pendingPostsCount || 0) + pendingReplies.length;
+  
+  // Set active tab to "pending" if there are pending posts/replies and user is a moderator
   useEffect(() => {
-    // Only change tab if we have pending posts and user is a moderator
-    if (isModerator && typeof pendingPostsCount === 'number' && pendingPostsCount > 0) {
+    // Only change tab if we have pending items and user is a moderator
+    if (isModerator && totalPendingCount > 0) {
       setActiveTab("pending");
     }
-  }, [isModerator, pendingPostsCount, setActiveTab]);
+  }, [isModerator, totalPendingCount, setActiveTab]);
 
 
   // Extract community data from tags
@@ -285,9 +292,9 @@ export default function GroupDetail() {
             <TabsTrigger value="pending" className="relative">
               <Clock className="h-4 w-4 mr-2" />
               Pending Approval
-              {typeof pendingPostsCount === 'number' && pendingPostsCount > 0 && (
+              {totalPendingCount > 0 && (
                 <span className="ml-2 bg-amber-500 text-white text-xs rounded-full px-2 py-0.5">
-                  {pendingPostsCount}
+                  {totalPendingCount}
                 </span>
               )}
             </TabsTrigger>


### PR DESCRIPTION
1. Replies to posts have to be approved by mod if not by a group member (re: #40)  
2. Added UI tab for Mods to review all pending posts and replies together at once 

![Screenshot from 2025-05-20 22-51-07](https://github.com/user-attachments/assets/fb8d2d6f-1663-40d7-b787-0b6256624ca0)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added a moderator-only "Pending Approval" tab showing counts of pending posts and replies in group detail pages.
    - Introduced lists for moderators to review and approve pending posts and replies within communities.
    - Enabled moderators to approve pending replies with in-app actions and notifications.
- **Enhancements**
    - Improved filtering of posts and replies to exclude replies from post lists and support pending-only views.
    - Integrated membership approval status into reply submission flow with tailored user feedback.
    - Added visual alerts and indicators for pending, approved, and auto-approved replies.
- **Bug Fixes**
    - Ensured accurate categorization by excluding replies from both pending and approved post listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->