### PR TITLE
Add "My Groups" Section

### DIFF
--- a/src/components/groups/MyGroupsList.tsx
+++ b/src/components/groups/MyGroupsList.tsx
@@ -1,0 +1,108 @@
+import { Link } from "react-router-dom";
+import { useUserGroups } from "@/hooks/useUserGroups";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import { Shield, Users, Crown } from "lucide-react";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { NostrEvent } from "@nostrify/nostrify";
+
+export function MyGroupsList() {
+  const { user } = useCurrentUser();
+  const { data: userGroups, isLoading } = useUserGroups();
+
+  if (!user) {
+    return null;
+  }
+
+  // If user has no groups and data is loaded, don't show the section
+  if (!isLoading && 
+      userGroups && 
+      userGroups.owned.length === 0 && 
+      userGroups.moderated.length === 0 && 
+      userGroups.member.length === 0) {
+    return null;
+  }
+
+  const renderGroupCard = (community: NostrEvent, role: "owner" | "moderator" | "member") => {
+    // Extract community data from tags
+    const nameTag = community.tags.find((tag: string[]) => tag[0] === "name");
+    const imageTag = community.tags.find((tag: string[]) => tag[0] === "image");
+    const dTag = community.tags.find((tag: string[]) => tag[0] === "d");
+
+    const name = nameTag ? nameTag[1] : (dTag ? dTag[1] : "Unnamed Community");
+    const image = imageTag ? imageTag[1] : "/placeholder-community.jpg";
+    const communityId = `34550:${community.pubkey}:${dTag ? dTag[1] : ""}`;
+
+    return (
+      <Card key={community.id} className="min-w-[250px] max-w-[250px] flex flex-col">
+        <div className="h-28 overflow-hidden">
+          {image && (
+            <img
+              src={image}
+              alt={name}
+              className="w-full h-full object-cover"
+              onError={(e) => {
+                e.currentTarget.src = "https://placehold.co/600x400?text=Community";
+              }}
+            />
+          )}
+        </div>
+        <CardHeader className="p-3">
+          <CardTitle className="text-base truncate flex items-center gap-1">
+            {role === "owner" && <Crown className="h-4 w-4 text-yellow-500" />}
+            {role === "moderator" && <Shield className="h-4 w-4 text-blue-500" />}
+            {role === "member" && <Users className="h-4 w-4 text-green-500" />}
+            {name}
+          </CardTitle>
+        </CardHeader>
+        <CardFooter className="p-3 pt-0 mt-auto">
+          <Button asChild variant="outline" size="sm" className="w-full">
+            <Link to={`/group/${encodeURIComponent(communityId)}`}>
+              Visit
+            </Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  };
+
+  return (
+    <div className="mb-8">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-2xl font-bold">My Groups</h2>
+        <Button asChild variant="outline" size="sm">
+          <Link to="/create-group">Create Group</Link>
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="flex gap-4 pb-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Card key={`skeleton-my-group-${index}`} className="min-w-[250px] max-w-[250px] flex flex-col">
+              <div className="h-28 overflow-hidden">
+                <Skeleton className="w-full h-full" />
+              </div>
+              <CardHeader className="p-3">
+                <Skeleton className="h-5 w-3/4" />
+              </CardHeader>
+              <CardFooter className="p-3 pt-0">
+                <Skeleton className="h-9 w-full" />
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      ) : (
+        <ScrollArea className="w-full whitespace-nowrap pb-2">
+          <div className="flex gap-4">
+            {userGroups?.owned.map(community => renderGroupCard(community, "owner"))}
+            {userGroups?.moderated.map(community => renderGroupCard(community, "moderator"))}
+            {userGroups?.member.map(community => renderGroupCard(community, "member"))}
+          </div>
+          <ScrollBar orientation="horizontal" />
+        </ScrollArea>
+      )}
+    </div>
+  );
+}

--- a/src/components/groups/MyGroupsList.tsx
+++ b/src/components/groups/MyGroupsList.tsx
@@ -128,9 +128,6 @@ export function MyGroupsList() {
     <div className="mb-8">
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-2xl font-bold">My Groups</h2>
-        <Button asChild variant="outline" size="sm">
-          <Link to="/create-group">Create Group</Link>
-        </Button>
       </div>
 
       {isLoading ? (

--- a/src/components/groups/MyGroupsList.tsx
+++ b/src/components/groups/MyGroupsList.tsx
@@ -4,13 +4,17 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/componen
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
-import { Shield, Users, Crown } from "lucide-react";
+import { Shield, Users, Crown, Pin, PinOff } from "lucide-react";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { NostrEvent } from "@nostrify/nostrify";
+import { usePinnedGroups } from "@/hooks/usePinnedGroups";
+import { cn } from "@/lib/utils";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 export function MyGroupsList() {
   const { user } = useCurrentUser();
   const { data: userGroups, isLoading } = useUserGroups();
+  const { pinGroup, unpinGroup, isGroupPinned, isUpdating } = usePinnedGroups();
 
   if (!user) {
     return null;
@@ -19,13 +23,14 @@ export function MyGroupsList() {
   // If user has no groups and data is loaded, don't show the section
   if (!isLoading && 
       userGroups && 
+      userGroups.pinned.length === 0 &&
       userGroups.owned.length === 0 && 
       userGroups.moderated.length === 0 && 
       userGroups.member.length === 0) {
     return null;
   }
 
-  const renderGroupCard = (community: NostrEvent, role: "owner" | "moderator" | "member") => {
+  const renderGroupCard = (community: NostrEvent, role: "pinned" | "owner" | "moderator" | "member") => {
     // Extract community data from tags
     const nameTag = community.tags.find((tag: string[]) => tag[0] === "name");
     const imageTag = community.tags.find((tag: string[]) => tag[0] === "image");
@@ -34,9 +39,32 @@ export function MyGroupsList() {
     const name = nameTag ? nameTag[1] : (dTag ? dTag[1] : "Unnamed Community");
     const image = imageTag ? imageTag[1] : "/placeholder-community.jpg";
     const communityId = `34550:${community.pubkey}:${dTag ? dTag[1] : ""}`;
+    
+    // Determine if this group is pinned
+    const isPinned = isGroupPinned(communityId);
+    
+    // Determine the actual role for the icon (pinned groups still show their original role icon)
+    const displayRole = role === "pinned" 
+      ? (community.pubkey === user?.pubkey ? "owner" : 
+         community.tags.some(tag => tag[0] === "p" && tag[1] === user?.pubkey && tag[3] === "moderator") ? "moderator" : "member")
+      : role;
+
+    const handleTogglePin = (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      
+      if (isPinned) {
+        unpinGroup(communityId);
+      } else {
+        pinGroup(communityId);
+      }
+    };
 
     return (
-      <Card key={community.id} className="min-w-[250px] max-w-[250px] flex flex-col">
+      <Card key={community.id} className={cn(
+        "min-w-[250px] max-w-[250px] flex flex-col relative group",
+        role === "pinned" && "ring-2 ring-primary/20"
+      )}>
         <div className="h-28 overflow-hidden">
           {image && (
             <img
@@ -51,9 +79,9 @@ export function MyGroupsList() {
         </div>
         <CardHeader className="p-3">
           <CardTitle className="text-base truncate flex items-center gap-1">
-            {role === "owner" && <Crown className="h-4 w-4 text-yellow-500" />}
-            {role === "moderator" && <Shield className="h-4 w-4 text-blue-500" />}
-            {role === "member" && <Users className="h-4 w-4 text-green-500" />}
+            {displayRole === "owner" && <Crown className="h-4 w-4 text-yellow-500" />}
+            {displayRole === "moderator" && <Shield className="h-4 w-4 text-blue-500" />}
+            {displayRole === "member" && <Users className="h-4 w-4 text-green-500" />}
             {name}
           </CardTitle>
         </CardHeader>
@@ -64,6 +92,34 @@ export function MyGroupsList() {
             </Link>
           </Button>
         </CardFooter>
+        
+        {/* Pin/Unpin Button */}
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button 
+                variant="ghost" 
+                size="icon" 
+                className={cn(
+                  "absolute top-2 right-2 h-8 w-8 rounded-full bg-background/80 opacity-0 group-hover:opacity-100 transition-opacity",
+                  isPinned && "opacity-100"
+                )}
+                onClick={handleTogglePin}
+                disabled={isUpdating}
+              >
+                {isPinned ? (
+                  <PinOff className="h-4 w-4" />
+                ) : (
+                  <Pin className="h-4 w-4" />
+                )}
+                <span className="sr-only">{isPinned ? "Unpin group" : "Pin group"}</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {isPinned ? "Unpin from My Groups" : "Pin to My Groups"}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </Card>
     );
   };
@@ -96,6 +152,10 @@ export function MyGroupsList() {
       ) : (
         <ScrollArea className="w-full whitespace-nowrap pb-2">
           <div className="flex gap-4">
+            {/* Pinned groups first */}
+            {userGroups?.pinned.map(community => renderGroupCard(community, "pinned"))}
+            
+            {/* Then other groups */}
             {userGroups?.owned.map(community => renderGroupCard(community, "owner"))}
             {userGroups?.moderated.map(community => renderGroupCard(community, "moderator"))}
             {userGroups?.member.map(community => renderGroupCard(community, "member"))}

--- a/src/hooks/usePinnedGroups.ts
+++ b/src/hooks/usePinnedGroups.ts
@@ -1,0 +1,130 @@
+import { useNostr } from "./useNostr";
+import { useCurrentUser } from "./useCurrentUser";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNostrPublish } from "./useNostrPublish";
+
+export interface PinnedGroup {
+  communityId: string;
+  relayUrl?: string;
+}
+
+export function usePinnedGroups() {
+  const { nostr } = useNostr();
+  const { user } = useCurrentUser();
+  const queryClient = useQueryClient();
+  const { mutate: publishEvent } = useNostrPublish();
+
+  // Fetch pinned groups
+  const query = useQuery({
+    queryKey: ["pinned-groups", user?.pubkey],
+    queryFn: async (c) => {
+      if (!user || !nostr) return [];
+
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      
+      // Fetch the user's pinned groups event (kind 14553)
+      const events = await nostr.query([
+        { 
+          kinds: [14553], 
+          authors: [user.pubkey],
+          limit: 1 
+        }
+      ], { signal });
+
+      // If no pinned groups event exists, return empty array
+      if (!events || events.length === 0) {
+        return [];
+      }
+
+      // Get the most recent event
+      const pinnedGroupsEvent = events[0];
+      
+      // Extract the pinned groups from the tags
+      const pinnedGroups: PinnedGroup[] = pinnedGroupsEvent.tags
+        .filter(tag => tag[0] === "a" && tag[1]?.startsWith("34550:"))
+        .map(tag => ({
+          communityId: tag[1],
+          relayUrl: tag[2] || undefined
+        }));
+
+      return pinnedGroups;
+    },
+    enabled: !!nostr && !!user,
+  });
+
+  // Mutation to update pinned groups
+  const updatePinnedGroups = useMutation({
+    mutationFn: async (pinnedGroups: PinnedGroup[]) => {
+      if (!user) throw new Error("User not logged in");
+
+      // Create tags for the event
+      const tags = pinnedGroups.map(group => 
+        group.relayUrl 
+          ? ["a", group.communityId, group.relayUrl] 
+          : ["a", group.communityId]
+      );
+
+      // Publish the kind 14553 event
+      await publishEvent({
+        kind: 14553,
+        tags,
+        content: ""
+      });
+
+      return pinnedGroups;
+    },
+    onSuccess: () => {
+      // Invalidate the pinned groups query to refetch
+      queryClient.invalidateQueries({ queryKey: ["pinned-groups", user?.pubkey] });
+      // Also invalidate user groups to update the UI
+      queryClient.invalidateQueries({ queryKey: ["user-groups", user?.pubkey] });
+    }
+  });
+
+  // Function to pin a group
+  const pinGroup = async (communityId: string, relayUrl?: string) => {
+    const currentPinnedGroups = query.data || [];
+    
+    // Check if group is already pinned
+    const isAlreadyPinned = currentPinnedGroups.some(
+      group => group.communityId === communityId
+    );
+    
+    if (isAlreadyPinned) return;
+    
+    // Add the group to the beginning of the list (highest priority)
+    const updatedPinnedGroups = [
+      { communityId, relayUrl },
+      ...currentPinnedGroups
+    ];
+    
+    await updatePinnedGroups.mutateAsync(updatedPinnedGroups);
+  };
+
+  // Function to unpin a group
+  const unpinGroup = async (communityId: string) => {
+    const currentPinnedGroups = query.data || [];
+    
+    // Filter out the group to unpin
+    const updatedPinnedGroups = currentPinnedGroups.filter(
+      group => group.communityId !== communityId
+    );
+    
+    await updatePinnedGroups.mutateAsync(updatedPinnedGroups);
+  };
+
+  // Function to check if a group is pinned
+  const isGroupPinned = (communityId: string) => {
+    const pinnedGroups = query.data || [];
+    return pinnedGroups.some(group => group.communityId === communityId);
+  };
+
+  return {
+    pinnedGroups: query.data || [],
+    isLoading: query.isLoading,
+    isUpdating: updatePinnedGroups.isPending,
+    pinGroup,
+    unpinGroup,
+    isGroupPinned
+  };
+}

--- a/src/hooks/useUserGroups.ts
+++ b/src/hooks/useUserGroups.ts
@@ -1,0 +1,83 @@
+import { useNostr } from "./useNostr";
+import { useCurrentUser } from "./useCurrentUser";
+import { useQuery } from "@tanstack/react-query";
+import { NostrEvent } from "@nostrify/nostrify";
+
+export function useUserGroups() {
+  const { nostr } = useNostr();
+  const { user } = useCurrentUser();
+
+  return useQuery({
+    queryKey: ["user-groups", user?.pubkey],
+    queryFn: async (c) => {
+      if (!user || !nostr) return { owned: [] as NostrEvent[], moderated: [] as NostrEvent[], member: [] as NostrEvent[] };
+
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
+      
+      // Fetch all communities
+      const allCommunities = await nostr.query([{ kinds: [34550], limit: 100 }], { signal });
+      
+      // Owned communities (where user is the creator)
+      const ownedCommunities = allCommunities.filter(
+        (community) => community.pubkey === user.pubkey
+      );
+      
+      // Moderated communities (where user is listed as a moderator)
+      const moderatedCommunities = allCommunities.filter(
+        (community) => 
+          community.pubkey !== user.pubkey && // Not already counted as owned
+          community.tags.some(tag => 
+            tag[0] === "p" && 
+            tag[1] === user.pubkey && 
+            tag[3] === "moderator"
+          )
+      );
+      
+      // Fetch approved members lists to find communities where user is a member
+      const approvedMembersLists = await nostr.query([
+        { 
+          kinds: [30000], 
+          "#d": ["approved-users"],
+          limit: 100 
+        }
+      ], { signal });
+      
+      // Communities where user is an approved member
+      const memberCommunities: NostrEvent[] = [];
+      
+      for (const list of approvedMembersLists) {
+        // Check if user is in this approved members list
+        const isApprovedMember = list.tags.some(tag => 
+          tag[0] === "p" && tag[1] === user.pubkey
+        );
+        
+        if (isApprovedMember) {
+          // Find which community this list belongs to
+          const communityRef = list.tags.find(tag => tag[0] === "a");
+          if (communityRef) {
+            const [_, pubkey, identifier] = communityRef[1].split(":");
+            
+            // Find the actual community event
+            const community = allCommunities.find(c => {
+              const dTag = c.tags.find(tag => tag[0] === "d");
+              return c.pubkey === pubkey && dTag && dTag[1] === identifier;
+            });
+            
+            if (community && 
+                !ownedCommunities.includes(community) && 
+                !moderatedCommunities.includes(community)) {
+              memberCommunities.push(community);
+            }
+          }
+        }
+      }
+      
+      return {
+        owned: ownedCommunities,
+        moderated: moderatedCommunities,
+        member: memberCommunities
+      };
+    },
+    enabled: !!nostr && !!user,
+  });
+}

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -19,9 +19,11 @@ import { PendingPostsList } from "@/components/groups/PendingPostsList";
 import { JoinRequestButton } from "@/components/groups/JoinRequestButton";
 import { MemberManagement } from "@/components/groups/MemberManagement";
 import { ApprovedMembersList } from "@/components/groups/ApprovedMembersList";
-import { Users, Settings, Info, MessageSquare, CheckCircle, UserPlus, Clock } from "lucide-react";
+import { Users, Settings, Info, MessageSquare, CheckCircle, UserPlus, Clock, Pin, PinOff } from "lucide-react";
 import { parseNostrAddress } from "@/lib/nostr-utils";
 import Header from "@/components/ui/Header";
+import { usePinnedGroups } from "@/hooks/usePinnedGroups";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 export default function GroupDetail() {
   const { groupId } = useParams<{ groupId: string }>();
@@ -31,6 +33,7 @@ export default function GroupDetail() {
   const [showOnlyApproved, setShowOnlyApproved] = useState(true);
   const [currentPostCount, setCurrentPostCount] = useState(0); // State for post count
   const [activeTab, setActiveTab] = useState("posts");
+  const { pinGroup, unpinGroup, isGroupPinned, isUpdating } = usePinnedGroups();
 
   useEffect(() => {
     if (groupId) {
@@ -137,7 +140,7 @@ export default function GroupDetail() {
       
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-4">
         <div className="md:col-span-2">
-          <div className="h-48 rounded-lg overflow-hidden mb-4"> {/* Changed mb-1.5 to mb-4 */}
+          <div className="h-48 rounded-lg overflow-hidden mb-4 relative group"> {/* Added relative and group */}
             <img
               src={image}
               alt={name}
@@ -146,6 +149,46 @@ export default function GroupDetail() {
                 e.currentTarget.src = "https://placehold.co/1200x400?text=Community";
               }}
             />
+            
+            {/* Pin/Unpin Button */}
+            {user && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button 
+                      variant="secondary" 
+                      size="icon" 
+                      className="absolute top-3 right-3 h-9 w-9 rounded-full bg-background/80 shadow-md"
+                      onClick={() => {
+                        const communityId = `34550:${parsedId?.pubkey}:${parsedId?.identifier}`;
+                        if (isGroupPinned(communityId)) {
+                          unpinGroup(communityId);
+                        } else {
+                          pinGroup(communityId);
+                        }
+                      }}
+                      disabled={isUpdating}
+                    >
+                      {isGroupPinned(`34550:${parsedId?.pubkey}:${parsedId?.identifier}`) ? (
+                        <PinOff className="h-5 w-5" />
+                      ) : (
+                        <Pin className="h-5 w-5" />
+                      )}
+                      <span className="sr-only">
+                        {isGroupPinned(`34550:${parsedId?.pubkey}:${parsedId?.identifier}`) 
+                          ? "Unpin from My Groups" 
+                          : "Pin to My Groups"}
+                      </span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {isGroupPinned(`34550:${parsedId?.pubkey}:${parsedId?.identifier}`) 
+                      ? "Unpin from My Groups" 
+                      : "Pin to My Groups"}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
           </div>
           <p className="text-lg mb-3">{description}</p>
         </div>

--- a/src/pages/Groups.tsx
+++ b/src/pages/Groups.tsx
@@ -4,10 +4,11 @@ import { Link } from "react-router-dom";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
-// import { Separator } from "@/components/ui/separator"; // Removed unused import
+import { Separator } from "@/components/ui/separator";
 import { Users } from "lucide-react";
 import Header from "@/components/ui/Header";
 import { Skeleton } from "@/components/ui/skeleton";
+import { MyGroupsList } from "@/components/groups/MyGroupsList";
 
 export default function Groups() {
   const { nostr } = useNostr();
@@ -26,6 +27,14 @@ export default function Groups() {
   return (
     <div className="container mx-auto py-4 px-6"> {/* Changed padding */}
       <Header />
+      
+      {/* My Groups Section */}
+      <MyGroupsList />
+      
+      {/* Separator between My Groups and All Communities */}
+      <Separator className="my-6" />
+      
+      <h2 className="text-2xl font-bold mb-6">All Communities</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {isLoading ? (
           // Skeleton loading state


### PR DESCRIPTION
Adds "My Groups" section and ability to pin groups to section. 

New event kind: 14553

![Screenshot from 2025-05-21 11-27-09](https://github.com/user-attachments/assets/b6cd4ef1-e074-4b8e-b48d-4b8ff1ba6e46)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "My Groups" section displaying a user's groups categorized by roles (pinned, owned, moderated, member) with visual role indicators.
  - Added the ability to pin or unpin groups directly from group cards and the group detail page, with interactive icons and tooltips.
  - Enabled horizontal scrolling for group lists and improved group navigation.

- **Enhancements**
  - Improved page layout by adding a visual separator between "My Groups" and "All Communities" sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->