### PR TITLE
Feat: Refactor 'community' to 'group' in UI and unify group list styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,20 +7,20 @@
     <!-- Primary Meta Tags -->
     <title>+chorus</title>
     <meta name="title" content="+chorus">
-    <meta name="description" content="Join, create, and participate in decentralized communities powered by the Nostr protocol. A Facebook-inspired groups platform built on NIP-72.">
+    <meta name="description" content="Join, create, and participate in decentralized groups powered by the Nostr protocol. A Facebook-inspired groups platform built on NIP-72.">
     
     <!-- Keywords -->
-    <meta name="keywords" content="nostr, communities, groups, decentralized, social media, NIP-72, web3">
+    <meta name="keywords" content="nostr, groups, decentralized, social media, NIP-72, web3">
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:title" content="+chorus">
-    <meta property="og:description" content="Join, create, and participate in decentralized communities powered by the Nostr protocol. A Facebook-inspired groups platform built on NIP-72.">
+    <meta property="og:description" content="Join, create, and participate in decentralized groups powered by the Nostr protocol. A Facebook-inspired groups platform built on NIP-72.">
     
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:title" content="+chorus">
-    <meta property="twitter:description" content="Join, create, and participate in decentralized communities powered by the Nostr protocol. A Facebook-inspired groups platform built on NIP-72.">
+    <meta property="twitter:description" content="Join, create, and participate in decentralized groups powered by the Nostr protocol. A Facebook-inspired groups platform built on NIP-72.">
     
     <!-- Theme Color -->
     <meta name="theme-color" content="#4f46e5">

--- a/src/components/auth/AccountSwitcher.tsx
+++ b/src/components/auth/AccountSwitcher.tsx
@@ -46,7 +46,7 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
         >
           <a href="/create-group">
             <Plus className='w-4 h-4 font-bold' />
-            <span>Create Community</span>
+            <span>Create Group</span>
           </a>
         </DropdownMenuItem>
         <DropdownMenuSeparator />

--- a/src/components/groups/CreatePostForm.tsx
+++ b/src/components/groups/CreatePostForm.tsx
@@ -49,7 +49,7 @@ export function CreatePostForm({ communityId }: CreatePostFormProps) {
     try {
       const parsedId = parseNostrAddress(communityId);
       if (!parsedId) {
-        toast.error("Invalid community ID");
+        toast.error("Invalid group ID");
         return;
       }
       
@@ -67,7 +67,7 @@ ${imageUrl}`;
       
       const tags = [
         ["a", communityId],
-        ["subject", "Post in " + communityId],
+        ["subject", `Post in ${parsedId?.identifier || 'group'}`],
         ...imageTags,
       ];
       

--- a/src/components/groups/PendingPostsList.tsx
+++ b/src/components/groups/PendingPostsList.tsx
@@ -49,7 +49,7 @@ export function PendingPostsList({ communityId }: PendingPostsListProps) {
           <CheckCircle className="h-4 w-4" />
           <AlertTitle>No pending posts</AlertTitle>
           <AlertDescription>
-            All posts have been reviewed. There are currently no posts waiting for approval in this community.
+            All posts have been reviewed. There are currently no posts waiting for approval in this group.
           </AlertDescription>
         </Alert>
       ) : (
@@ -59,7 +59,7 @@ export function PendingPostsList({ communityId }: PendingPostsListProps) {
             <AlertTitle>Pending Approval</AlertTitle>
             <AlertDescription>
               These posts are from users who are not approved members, moderators, or the group owner.
-              They need your approval before they will be visible to all community members.
+              They need your approval before they will be visible to all group members.
             </AlertDescription>
           </Alert>
           

--- a/src/components/groups/PendingRepliesList.tsx
+++ b/src/components/groups/PendingRepliesList.tsx
@@ -44,7 +44,7 @@ export function PendingRepliesList({ communityId }: PendingRepliesListProps) {
         <CheckCircle className="h-4 w-4" />
         <AlertTitle>No pending replies</AlertTitle>
         <AlertDescription>
-          All replies have been reviewed. There are currently no replies waiting for approval in this community.
+          All replies have been reviewed. There are currently no replies waiting for approval in this group.
         </AlertDescription>
       </Alert>
     );
@@ -64,7 +64,7 @@ export function PendingRepliesList({ communityId }: PendingRepliesListProps) {
         <AlertTitle>Pending Reply Approval</AlertTitle>
         <AlertDescription>
           These replies are from users who are not approved members, moderators, or the group owner. 
-          They need your approval before they will be visible to all community members.
+          They need your approval before they will be visible to all group members.
         </AlertDescription>
       </Alert>
       

--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -316,10 +316,10 @@ export function PostList({ communityId, showOnlyApproved = false, pendingOnly = 
       <Card className="p-8 text-center">
         <p className="text-muted-foreground mb-2">
           {showOnlyApproved 
-            ? "No approved posts in this community yet" 
+            ? "No approved posts in this group yet" 
             : pendingOnly
-              ? "No pending posts in this community"
-              : "No posts in this community yet"}
+              ? "No pending posts in this group"
+              : "No posts in this group yet"}
         </p>
         <p className="text-sm">
           {showOnlyApproved && pendingCount > 0
@@ -550,10 +550,10 @@ function PostItem({ post, communityId, isApproved, isModerator }: PostItemProps)
                   </DropdownMenuContent>
                 </DropdownMenu>
                 <AlertDialog open={isRemoveDialogOpen} onOpenChange={setIsRemoveDialogOpen}>
-                  <AlertDialogContent><AlertDialogHeader><AlertDialogTitle>Remove Post</AlertDialogTitle><AlertDialogDescription>Are you sure you want to remove this post? This action will hide the post from the community.</AlertDialogDescription></AlertDialogHeader><AlertDialogFooter><AlertDialogCancel>Cancel</AlertDialogCancel><AlertDialogAction onClick={handleRemovePost} className="bg-red-600 hover:bg-red-700">Remove Post</AlertDialogAction></AlertDialogFooter></AlertDialogContent>
+                  <AlertDialogContent><AlertDialogHeader><AlertDialogTitle>Remove Post</AlertDialogTitle><AlertDialogDescription>Are you sure you want to remove this post? This action will hide the post from the group.</AlertDialogDescription></AlertDialogHeader><AlertDialogFooter><AlertDialogCancel>Cancel</AlertDialogCancel><AlertDialogAction onClick={handleRemovePost} className="bg-red-600 hover:bg-red-700">Remove Post</AlertDialogAction></AlertDialogFooter></AlertDialogContent>
                 </AlertDialog>
                 <AlertDialog open={isBanDialogOpen} onOpenChange={setIsBanDialogOpen}>
-                  <AlertDialogContent><AlertDialogHeader><AlertDialogTitle>Ban User</AlertDialogTitle><AlertDialogDescription>Are you sure you want to ban this user? They will no longer be able to post in this community, and all their existing posts will be hidden.</AlertDialogDescription></AlertDialogHeader><AlertDialogFooter><AlertDialogCancel>Cancel</AlertDialogCancel><AlertDialogAction onClick={handleBanUser} className="bg-red-600 hover:bg-red-700">Ban User</AlertDialogAction></AlertDialogFooter></AlertDialogContent>
+                  <AlertDialogContent><AlertDialogHeader><AlertDialogTitle>Ban User</AlertDialogTitle><AlertDialogDescription>Are you sure you want to ban this user? They will no longer be able to post in this group, and all their existing posts will be hidden.</AlertDialogDescription></AlertDialogHeader><AlertDialogFooter><AlertDialogCancel>Cancel</AlertDialogCancel><AlertDialogAction onClick={handleBanUser} className="bg-red-600 hover:bg-red-700">Ban User</AlertDialogAction></AlertDialogFooter></AlertDialogContent>
                 </AlertDialog>
               </div>
             )}

--- a/src/pages/CreateGroup.tsx
+++ b/src/pages/CreateGroup.tsx
@@ -11,6 +11,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { toast } from "sonner";
 import { ArrowLeft, Upload } from "lucide-react";
 import Header from "@/components/ui/Header";
+import { Separator } from "@/components/ui/separator"; // Added Separator import
 
 export default function CreateGroup() {
   const navigate = useNavigate();
@@ -32,9 +33,9 @@ export default function CreateGroup() {
   if (!user) {
     return (
       <div className="container mx-auto py-4 px-6"> {/* Changed padding */}
-        <h1 className="text-2xl font-bold mb-4">You must be logged in to create a community</h1>
+        <h1 className="text-2xl font-bold mb-4">You must be logged in to create a group</h1>
         <Button asChild>
-          <Link to="/groups">Back to Communities</Link>
+          <Link to="/groups">Back to Groups</Link>
         </Button>
       </div>
     );
@@ -99,11 +100,11 @@ export default function CreateGroup() {
         content: "",
       });
 
-      toast.success("Community created successfully!");
+      toast.success("Group created successfully!");
       navigate("/groups");
     } catch (error) {
       console.error("Error creating community:", error);
-      toast.error("Failed to create community. Please try again.");
+      toast.error("Failed to create group. Please try again.");
     } finally {
       setIsSubmitting(false);
     }
@@ -112,30 +113,31 @@ export default function CreateGroup() {
   return (
     <div className="container mx-auto py-4 px-6"> {/* Changed padding */}
       <Header />
+      <Separator className="my-4" />
 
       <Card>
         <CardHeader>
-          <CardTitle>Create a Community</CardTitle>
+          <CardTitle>Create a Group</CardTitle>
         </CardHeader>
         <form onSubmit={handleSubmit}>
           <CardContent className="space-y-6">
             <div className="space-y-2">
-              <Label htmlFor="name">Community Name *</Label>
+              <Label htmlFor="name">Group Name *</Label>
               <Input
                 id="name"
                 name="name"
                 value={formData.name}
                 onChange={handleInputChange}
-                placeholder="My Awesome Community"
+                placeholder="My Awesome Group"
                 required
               />
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="identifier">
-                Community Identifier *
+                Group Identifier *
                 <span className="text-xs text-muted-foreground ml-2">
-                  (unique identifier for your community)
+                  (unique identifier for your group)
                 </span>
               </Label>
               <Input
@@ -143,7 +145,7 @@ export default function CreateGroup() {
                 name="identifier"
                 value={formData.identifier}
                 onChange={handleInputChange}
-                placeholder="my-awesome-community"
+                placeholder="my-awesome-group"
                 required
               />
             </div>
@@ -155,14 +157,14 @@ export default function CreateGroup() {
                 name="description"
                 value={formData.description}
                 onChange={handleInputChange}
-                placeholder="Tell people what your community is about..."
+                placeholder="Tell people what your group is about..."
                 rows={4}
                 required
               />
             </div>
 
             <div className="space-y-2">
-              <Label>Community Image</Label>
+              <Label>Group Image</Label>
               <div className="flex items-start gap-4">
                 <div className="flex-1">
                   <div className="flex items-center gap-2">
@@ -185,7 +187,7 @@ export default function CreateGroup() {
                     />
                   </div>
                   <p className="text-xs text-muted-foreground mt-1">
-                    Upload an image or provide a URL for your community banner
+                    Upload an image or provide a URL for your group banner
                   </p>
                 </div>
 
@@ -214,7 +216,7 @@ export default function CreateGroup() {
               type="submit"
               disabled={isSubmitting || isUploading || !formData.name || !formData.identifier || !formData.description}
             >
-              {isSubmitting || isUploading ? "Creating..." : "Create Community"}
+              {isSubmitting || isUploading ? "Creating..." : "Create Group"}
             </Button>
           </CardFooter>
         </form>

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -24,6 +24,7 @@ import { parseNostrAddress } from "@/lib/nostr-utils";
 import Header from "@/components/ui/Header";
 import { usePinnedGroups } from "@/hooks/usePinnedGroups";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Separator } from "@/components/ui/separator"; // Added Separator import
 
 export default function GroupDetail() {
   const { groupId } = useParams<{ groupId: string }>();
@@ -58,7 +59,7 @@ export default function GroupDetail() {
         "#d": [parsedId.identifier]
       }], { signal });
 
-      if (events.length === 0) throw new Error("Community not found");
+      if (events.length === 0) throw new Error("Community not found"); // This error message is internal, can stay
       return events[0];
     },
     enabled: !!nostr && !!parsedId,
@@ -96,12 +97,12 @@ export default function GroupDetail() {
   const imageTag = community?.tags.find(tag => tag[0] === "image");
   const moderatorTags = community?.tags.filter(tag => tag[0] === "p" && tag[3] === "moderator") || [];
 
-  const name = nameTag ? nameTag[1] : (parsedId?.identifier || "Unnamed Community");
+  const name = nameTag ? nameTag[1] : (parsedId?.identifier || "Unnamed Group");
   const description = descriptionTag ? descriptionTag[1] : "No description available";
-  const image = imageTag ? imageTag[1] : "/placeholder-community.jpg";
+  const image = imageTag ? imageTag[1] : "/placeholder-community.jpg"; // Placeholder image path, might not need changing
 
   useEffect(() => {
-    if (name && name !== "Unnamed Community") {
+    if (name && name !== "Unnamed Group") { // Adjusted check
       document.title = `+chorus - ${name}`;
     } else {
       document.title = "+chorus"; // Default if name isn't available
@@ -117,7 +118,8 @@ export default function GroupDetail() {
     return (
       <div className="container mx-auto py-4 px-6">
         <Header />
-        <h1 className="text-2xl font-bold mb-4">Loading community...</h1>
+        <Separator className="my-4" />
+        <h1 className="text-2xl font-bold mb-4">Loading group...</h1>
       </div>
     );
   }
@@ -125,10 +127,10 @@ export default function GroupDetail() {
   if (!community) {
     return (
       <div className="container mx-auto py-4 px-6">
-        <h1 className="text-2xl font-bold mb-4">Community not found</h1>
-        <p>The community you're looking for doesn't exist or has been deleted.</p>
+        <h1 className="text-2xl font-bold mb-4">Group not found</h1>
+        <p>The group you're looking for doesn't exist or has been deleted.</p>
         <Button asChild className="mt-4">
-          <Link to="/groups">Back to Communities</Link>
+          <Link to="/groups">Back to Groups</Link>
         </Button>
       </div>
     );
@@ -137,6 +139,7 @@ export default function GroupDetail() {
   return (
     <div className="container mx-auto py-4 px-6">
       <Header />
+      <Separator className="my-4" />
       
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-4">
         <div className="md:col-span-2">
@@ -146,7 +149,7 @@ export default function GroupDetail() {
               alt={name}
               className="w-full h-full object-cover"
               onError={(e) => {
-                e.currentTarget.src = "https://placehold.co/1200x400?text=Community";
+                e.currentTarget.src = "https://placehold.co/1200x400?text=Group";
               }}
             />
             
@@ -160,7 +163,7 @@ export default function GroupDetail() {
                       size="icon" 
                       className="absolute top-3 right-3 h-9 w-9 rounded-full bg-background/80 shadow-md"
                       onClick={() => {
-                        const communityId = `34550:${parsedId?.pubkey}:${parsedId?.identifier}`;
+                        const communityId = `34550:${parsedId?.pubkey}:${parsedId?.identifier}`; // Keep communityId for protocol consistency
                         if (isGroupPinned(communityId)) {
                           unpinGroup(communityId);
                         } else {
@@ -203,15 +206,15 @@ export default function GroupDetail() {
                 </CardTitle>
                 <CardDescription>
                   {isOwner
-                    ? "You are the owner of this community"
-                    : "You are a moderator of this community"}
+                    ? "You are the owner of this group"
+                    : "You are a moderator of this group"}
                 </CardDescription>
               </CardHeader>
               <CardContent className="flex justify-center py-4">
                 <Button asChild variant="outline" className="w-full">
                   <Link to={`/group/${encodeURIComponent(groupId || '')}/settings`} className="w-full flex items-center justify-center gap-2">
                     <Settings className="h-4 w-4" />
-                    Manage Community
+                    Manage Group
                   </Link>
                 </Button>
               </CardContent>
@@ -224,7 +227,7 @@ export default function GroupDetail() {
                   Join this group
                 </CardTitle>
                 <CardDescription>
-                  Request to join this community to participate in discussions
+                  Request to join this group to participate in discussions
                 </CardDescription>
               </CardHeader>
               <CardContent className="flex justify-center py-4">
@@ -327,7 +330,7 @@ export default function GroupDetail() {
         <TabsContent value="about">
           <Card>
             <CardHeader>
-              <CardTitle>About this Community</CardTitle>
+              <CardTitle>About this Group</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div>

--- a/src/pages/GroupSettings.tsx
+++ b/src/pages/GroupSettings.tsx
@@ -55,7 +55,7 @@ export default function GroupSettings() {
         "#d": [parsedId.identifier]
       }], { signal });
       
-      if (events.length === 0) throw new Error("Community not found");
+      if (events.length === 0) throw new Error("Community not found"); // Internal error message
       return events[0];
     },
     enabled: !!nostr && !!parsedId
@@ -127,12 +127,12 @@ export default function GroupSettings() {
     e.preventDefault();
     
     if (!user) {
-      toast.error("You must be logged in to update community settings");
+      toast.error("You must be logged in to update group settings");
       return;
     }
     
     if (!parsedId) {
-      toast.error("Invalid community ID");
+      toast.error("Invalid group ID");
       return;
     }
     
@@ -150,7 +150,7 @@ export default function GroupSettings() {
     }
     
     if (!isModerator && !isOwner) {
-      toast.error("You must be a moderator or the group owner to update community settings");
+      toast.error("You must be a moderator or the group owner to update group settings");
       return;
     }
     
@@ -195,11 +195,11 @@ export default function GroupSettings() {
         content: "",
       });
       
-      toast.success("Community settings updated successfully!");
+      toast.success("Group settings updated successfully!");
       navigate(`/group/${encodeURIComponent(groupId || "")}`);
     } catch (error) {
       console.error("Error updating community settings:", error);
-      toast.error("Failed to update community settings. Please try again.");
+      toast.error("Failed to update group settings. Please try again.");
     }
   };
   
@@ -288,7 +288,7 @@ export default function GroupSettings() {
   if (isLoadingCommunity) {
     return (
       <div className="container mx-auto py-4 px-6"> {/* Changed padding */}
-        <h1 className="text-2xl font-bold mb-4">Loading community settings...</h1>
+        <h1 className="text-2xl font-bold mb-4">Loading group settings...</h1>
       </div>
     );
   }
@@ -296,10 +296,10 @@ export default function GroupSettings() {
   if (!community) {
     return (
       <div className="container mx-auto py-4 px-6"> {/* Changed padding */}
-        <h1 className="text-2xl font-bold mb-4">Community not found</h1>
-        <p>The community you're looking for doesn't exist or has been deleted.</p>
+        <h1 className="text-2xl font-bold mb-4">Group not found</h1>
+        <p>The group you're looking for doesn't exist or has been deleted.</p>
         <Button asChild className="mt-4">
-          <Link to="/groups">Back to Communities</Link>
+          <Link to="/groups">Back to Groups</Link>
         </Button>
       </div>
     );
@@ -309,9 +309,9 @@ export default function GroupSettings() {
     return (
       <div className="container mx-auto py-4 px-6"> {/* Changed padding */}
         <h1 className="text-2xl font-bold mb-4">Access Denied</h1>
-        <p>You must be a moderator or the group owner to access community settings.</p>
+        <p>You must be a moderator or the group owner to access group settings.</p>
         <Button asChild className="mt-4">
-          <Link to={`/group/${encodeURIComponent(groupId || "")}`}>Back to Community</Link>
+          <Link to={`/group/${encodeURIComponent(groupId || "")}`}>Back to Group</Link>
         </Button>
       </div>
     );
@@ -323,10 +323,10 @@ export default function GroupSettings() {
         <Button variant="ghost" size="sm" asChild className="mr-2">
           <Link to={`/group/${encodeURIComponent(groupId || "")}`}>
             <ArrowLeft className="h-4 w-4 mr-1" />
-            Back to Community
+            Back to Group
           </Link>
         </Button>
-        <h1 className="text-2xl font-bold">Community Settings</h1>
+        <h1 className="text-2xl font-bold">Group Settings</h1>
       </div>
       
       <Tabs defaultValue="general" className="w-full">
@@ -343,17 +343,17 @@ export default function GroupSettings() {
               <CardHeader>
                 <CardTitle>General Settings</CardTitle>
                 <CardDescription>
-                  Update your community's basic information
+                  Update your group's basic information
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="space-y-2">
-                  <Label htmlFor="name">Community Name</Label>
+                  <Label htmlFor="name">Group Name</Label>
                   <Input 
                     id="name" 
                     value={name} 
                     onChange={(e) => setName(e.target.value)} 
-                    placeholder="Enter community name"
+                    placeholder="Enter group name"
                     required
                   />
                 </div>
@@ -364,7 +364,7 @@ export default function GroupSettings() {
                     id="description" 
                     value={description} 
                     onChange={(e) => setDescription(e.target.value)} 
-                    placeholder="Enter community description"
+                    placeholder="Enter group description"
                     rows={4}
                   />
                 </div>
@@ -382,7 +382,7 @@ export default function GroupSettings() {
                     <div className="mt-2 rounded-md overflow-hidden border w-full max-w-xs">
                       <img 
                         src={imageUrl} 
-                        alt="Community preview" 
+                        alt="Group preview" 
                         className="w-full h-auto"
                         onError={(e) => {
                           e.currentTarget.src = "https://placehold.co/400x200?text=Invalid+Image";
@@ -393,7 +393,7 @@ export default function GroupSettings() {
                 </div>
 
                 <div className="mt-4 p-3 bg-muted rounded-md">
-                  <h3 className="text-sm font-medium mb-2">Current Community Information</h3>
+                  <h3 className="text-sm font-medium mb-2">Current Group Information</h3>
                   <p className="text-xs text-muted-foreground mb-1">
                     <span className="font-medium">ID:</span> {parsedId?.identifier}
                   </p>
@@ -424,7 +424,7 @@ export default function GroupSettings() {
                   </CardTitle>
                   <CardDescription>
                     {isOwner 
-                      ? "As the group owner, you can manage who can moderate this community"
+                      ? "As the group owner, you can manage who can moderate this group"
                       : "Only the group owner can add or remove moderators"}
                   </CardDescription>
                 </CardHeader>
@@ -466,7 +466,7 @@ export default function GroupSettings() {
                 <CardHeader>
                   <CardTitle className="flex items-center">
                     <Users className="h-5 w-5 mr-2" />
-                    Community Members
+                    Group Members
                   </CardTitle>
                   <CardDescription>
                     {isOwner 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -15,6 +15,7 @@ import { toast } from "sonner";
 import type { NostrEvent } from "@nostrify/nostrify";
 import { parseNostrAddress } from "@/lib/nostr-utils";
 import Header from "@/components/ui/Header";
+import { Separator } from "@/components/ui/separator"; // Added Separator import
 
 // Helper function to extract group information from a post
 function extractGroupInfo(post: NostrEvent): { groupId: string; groupName: string } | null {
@@ -48,7 +49,7 @@ function extractGroupInfo(post: NostrEvent): { groupId: string; groupName: strin
 
   return {
     groupId,
-    groupName: "Community" // Fallback name if we can't extract it
+    groupName: "Group" // Fallback name if we can't extract it
   };
 }
 
@@ -267,7 +268,7 @@ export default function Profile() {
           id: groupId,
           name: nameTag ? nameTag[1] : parsedGroup.identifier,
           description: descriptionTag ? descriptionTag[1] : "",
-          image: imageTag ? imageTag[1] : "/placeholder-community.jpg",
+          image: imageTag ? imageTag[1] : "/placeholder-group.jpg", // Updated placeholder
           membershipEvent: event,
           groupEvent: groupEvent,
         };
@@ -317,6 +318,7 @@ export default function Profile() {
     return (
       <div className="container mx-auto py-4 px-6"> {/* Changed padding */}
         <Header />
+        <Separator className="my-4" />
         <Card className="mb-8">
           <CardHeader className="flex flex-row items-center gap-4">
             <Skeleton className="h-24 w-24 rounded-full" />
@@ -430,6 +432,7 @@ export default function Profile() {
   return (
     <div className="container mx-auto py-4 px-6"> {/* Changed padding */}
       <Header />
+      <Separator className="my-4" />
       <Card className="mb-8">
         <CardHeader className="flex flex-row items-start gap-6">
           <Avatar className="h-24 w-24">


### PR DESCRIPTION
This PR includes:
- Replacement of \'community\' and \'communities\' with \'group\' and \'groups\' in user-facing text throughout the application.
- Addition of a visual separator line directly under the main header on most pages.
- Removal of the separator line that was between the \'My Groups\' section and the \'All Groups\' list on the groups page.
- Unification of the card styling for \'My Groups\' and \'All Groups\' to ensure a consistent look and feel.
- Addition of pin/unpin functionality to the \'All Groups\' cards, matching the behavior in \'My Groups\'.
- Adjustment of the pinned group indicator border to `ring-1` for a thinner appearance.
- Update of group list grids to display 4 cards per row on large screens (`lg:grid-cols-4\').

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to pin and unpin groups on the Groups page for easier access.

- **UI Enhancements**
  - Updated all user-facing terminology from "community" to "group" across the platform for consistency.
  - Improved group card layouts with a responsive grid, richer metadata (including group descriptions and moderator counts), and updated visual separators.
  - Enhanced default images and placeholder text to reflect the new terminology.

- **Bug Fixes**
  - Updated error and alert messages to reference "group" instead of "community" for clearer user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->