### PR TITLE
WIP: Fix notifications

### DIFF
--- a/src/components/groups/GroupReference.tsx
+++ b/src/components/groups/GroupReference.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useNostr } from "@/hooks/useNostr";
+import { Badge } from "@/components/ui/badge";
+import { parseNostrAddress } from "@/lib/nostr-utils";
+
+interface GroupReferenceProps {
+  groupId: string;
+}
+
+export function GroupReference({ groupId }: GroupReferenceProps) {
+  const { nostr } = useNostr();
+  const [groupName, setGroupName] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchGroupInfo = async () => {
+      try {
+        setIsLoading(true);
+        const parsedAddress = parseNostrAddress(groupId);
+        
+        if (!parsedAddress || parsedAddress.kind !== 34550) {
+          console.error("Invalid group ID format:", groupId);
+          setIsLoading(false);
+          return;
+        }
+
+        const events = await nostr.query(
+          [{ 
+            kinds: [34550], 
+            authors: [parsedAddress.pubkey], 
+            "#d": [parsedAddress.identifier] 
+          }],
+          { signal: AbortSignal.timeout(3000) }
+        );
+
+        if (events.length > 0) {
+          const nameTag = events[0].tags.find(tag => tag[0] === "name");
+          setGroupName(nameTag ? nameTag[1] : parsedAddress.identifier);
+        } else {
+          setGroupName(parsedAddress.identifier);
+        }
+      } catch (error) {
+        console.error("Error fetching group info:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (groupId) {
+      fetchGroupInfo();
+    }
+  }, [groupId, nostr]);
+
+  if (isLoading) {
+    return <Badge variant="outline" className="animate-pulse">Loading group...</Badge>;
+  }
+
+  if (!groupName) {
+    return null;
+  }
+
+  return (
+    <Badge variant="secondary" className="ml-1">
+      <Link to={`/group/${encodeURIComponent(groupId)}`} className="hover:underline">
+        {groupName}
+      </Link>
+    </Badge>
+  );
+}

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -87,10 +87,11 @@ export function useNotifications() {
             notifications.push({
               id: event.id,
               type: 'post_approved',
-              message: `Your post to a group was approved`,
+              message: `approved your post to a group`,
               createdAt: event.created_at,
               read: !!readNotifications[event.id],
               eventId: event.tags.find(tag => tag[0] === 'e')?.[1],
+              pubkey: event.pubkey,
               groupId: communityRef
             });
             break;
@@ -102,10 +103,11 @@ export function useNotifications() {
             notifications.push({
               id: event.id,
               type: 'post_removed',
-              message: `Your post to a group was removed`,
+              message: `removed your post from a group`,
               createdAt: event.created_at,
               read: !!readNotifications[event.id],
               eventId: event.tags.find(tag => tag[0] === 'e')?.[1],
+              pubkey: event.pubkey,
               groupId: communityRef
             });
             break;

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -43,7 +43,7 @@ export function useNotifications() {
             notifications.push({
               id: event.id,
               type: 'tag_post',
-              message: `You were tagged in a post`,
+              message: `tagged you in a post`,
               createdAt: event.created_at,
               read: !!readNotifications[event.id],
               eventId: event.id,
@@ -71,7 +71,7 @@ export function useNotifications() {
             notifications.push({
               id: event.id,
               type: 'tag_reply',
-              message: `You were tagged in a reply`,
+              message: `tagged you in a reply`,
               createdAt: event.created_at,
               read: !!readNotifications[event.id],
               eventId: event.id,

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -58,7 +58,7 @@ export function useNotifications() {
             notifications.push({
               id: event.id,
               type: 'reaction',
-              message: `Someone reacted to your post`,
+              message: `reacted to your post`,
               createdAt: event.created_at,
               read: !!readNotifications[event.id],
               eventId: targetEventId,

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -33,6 +33,11 @@ export function useNotifications() {
       );
 
       for (const event of events) {
+        // Extract group ID from 'a' tag if present (for all notification types)
+        const communityRef = event.tags.find(tag => tag[0] === 'a')?.[1];
+        const communityParts = communityRef?.split(':');
+        const groupId = communityParts && communityParts[0] === '34550' ? communityRef : undefined;
+        
         switch (event.kind) {
           case 1: {
             notifications.push({
@@ -42,7 +47,8 @@ export function useNotifications() {
               createdAt: event.created_at,
               read: !!readNotifications[event.id],
               eventId: event.id,
-              pubkey: event.pubkey
+              pubkey: event.pubkey,
+              groupId
             });
             break;
           }
@@ -56,7 +62,8 @@ export function useNotifications() {
               createdAt: event.created_at,
               read: !!readNotifications[event.id],
               eventId: targetEventId,
-              pubkey: event.pubkey
+              pubkey: event.pubkey,
+              groupId
             });
             break;
           }
@@ -68,14 +75,14 @@ export function useNotifications() {
               createdAt: event.created_at,
               read: !!readNotifications[event.id],
               eventId: event.id,
-              pubkey: event.pubkey
+              pubkey: event.pubkey,
+              groupId
             });
             break;
           }
           case 4550: {
+            // For post approval events, we already have the full community reference in the 'a' tag
             const communityRef = event.tags.find(tag => tag[0] === 'a')?.[1];
-            const communityParts = communityRef?.split(':');
-            const groupId = communityParts?.[2];
             
             notifications.push({
               id: event.id,
@@ -84,14 +91,13 @@ export function useNotifications() {
               createdAt: event.created_at,
               read: !!readNotifications[event.id],
               eventId: event.tags.find(tag => tag[0] === 'e')?.[1],
-              groupId
+              groupId: communityRef
             });
             break;
           }
           case 4551: {
+            // For post removal events, we already have the full community reference in the 'a' tag
             const communityRef = event.tags.find(tag => tag[0] === 'a')?.[1];
-            const communityParts = communityRef?.split(':');
-            const groupId = communityParts?.[2];
             
             notifications.push({
               id: event.id,
@@ -100,13 +106,15 @@ export function useNotifications() {
               createdAt: event.created_at,
               read: !!readNotifications[event.id],
               eventId: event.tags.find(tag => tag[0] === 'e')?.[1],
-              groupId
+              groupId: communityRef
             });
             break;
           }
           case 34550: {
-            const groupId = event.tags.find(tag => tag[0] === 'd')?.[1];
+            const dTag = event.tags.find(tag => tag[0] === 'd')?.[1];
             const groupName = event.tags.find(tag => tag[0] === 'name')?.[1] || 'Unknown group';
+            // Create the full community reference in the format "34550:pubkey:identifier"
+            const fullGroupId = `34550:${event.pubkey}:${dTag}`;
             
             notifications.push({
               id: event.id,
@@ -115,7 +123,7 @@ export function useNotifications() {
               createdAt: event.created_at,
               read: !!readNotifications[event.id],
               eventId: event.id,
-              groupId
+              groupId: fullGroupId
             });
             break;
           }

--- a/src/pages/settings/Notifications.tsx
+++ b/src/pages/settings/Notifications.tsx
@@ -91,7 +91,7 @@ export default function Notifications() {
               <div className="text-sm text-muted-foreground">
                 {formatDistanceToNow(notification.createdAt * 1000, { addSuffix: true })}
               </div>
-              {linkTo && (
+              {linkTo && notification.groupId && (
                 <Button variant="link" className="p-0 h-auto mt-1" asChild>
                   <Link to={linkTo}>View details</Link>
                 </Button>

--- a/src/pages/settings/Notifications.tsx
+++ b/src/pages/settings/Notifications.tsx
@@ -84,9 +84,9 @@ export default function Notifications() {
             )}
             <div className="flex-1">
               <div className="font-medium">
-                {notification.pubkey && (notification.type === 'reaction' || notification.type === 'tag_post' || notification.type === 'tag_reply') ? `${authorName} ` : ''}
+                {notification.pubkey && (notification.type === 'reaction' || notification.type === 'tag_post' || notification.type === 'tag_reply' || notification.type === 'post_approved' || notification.type === 'post_removed') ? `${authorName} ` : ''}
                 {notification.message}
-                {notification.pubkey && (notification.type !== 'reaction' && notification.type !== 'tag_post' && notification.type !== 'tag_reply') && ` from ${authorName}`}
+                {notification.pubkey && (notification.type !== 'reaction' && notification.type !== 'tag_post' && notification.type !== 'tag_reply' && notification.type !== 'post_approved' && notification.type !== 'post_removed') && ` from ${authorName}`}
                 {notification.groupId && <GroupReference groupId={notification.groupId} />}
               </div>
               <div className="text-sm text-muted-foreground">

--- a/src/pages/settings/Notifications.tsx
+++ b/src/pages/settings/Notifications.tsx
@@ -84,8 +84,9 @@ export default function Notifications() {
             )}
             <div className="flex-1">
               <div className="font-medium">
+                {notification.pubkey && notification.type === 'reaction' ? `${authorName} ` : ''}
                 {notification.message}
-                {notification.pubkey && ` from ${authorName}`}
+                {notification.pubkey && notification.type !== 'reaction' && ` from ${authorName}`}
                 {notification.groupId && <GroupReference groupId={notification.groupId} />}
               </div>
               <div className="text-sm text-muted-foreground">

--- a/src/pages/settings/Notifications.tsx
+++ b/src/pages/settings/Notifications.tsx
@@ -9,6 +9,7 @@ import { useNotifications, useMarkNotificationAsRead, Notification } from "@/hoo
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useAuthor } from "@/hooks/useAuthor";
 import { formatDistanceToNow } from "date-fns";
+import { GroupReference } from "@/components/groups/GroupReference";
 
 export default function Notifications() {
   const { user } = useCurrentUser();
@@ -85,6 +86,7 @@ export default function Notifications() {
               <div className="font-medium">
                 {notification.message}
                 {notification.pubkey && ` from ${authorName}`}
+                {notification.groupId && <GroupReference groupId={notification.groupId} />}
               </div>
               <div className="text-sm text-muted-foreground">
                 {formatDistanceToNow(notification.createdAt * 1000, { addSuffix: true })}
@@ -120,7 +122,7 @@ export default function Notifications() {
           <CardHeader>
             <CardTitle>Your Notifications</CardTitle>
             <CardDescription>
-              Stay updated on activity related to your account and communities
+              Stay updated on activity related to your account and groups
             </CardDescription>
           </CardHeader>
           <CardContent>

--- a/src/pages/settings/Notifications.tsx
+++ b/src/pages/settings/Notifications.tsx
@@ -84,9 +84,9 @@ export default function Notifications() {
             )}
             <div className="flex-1">
               <div className="font-medium">
-                {notification.pubkey && notification.type === 'reaction' ? `${authorName} ` : ''}
+                {notification.pubkey && (notification.type === 'reaction' || notification.type === 'tag_post' || notification.type === 'tag_reply') ? `${authorName} ` : ''}
                 {notification.message}
-                {notification.pubkey && notification.type !== 'reaction' && ` from ${authorName}`}
+                {notification.pubkey && (notification.type !== 'reaction' && notification.type !== 'tag_post' && notification.type !== 'tag_reply') && ` from ${authorName}`}
                 {notification.groupId && <GroupReference groupId={notification.groupId} />}
               </div>
               <div className="text-sm text-muted-foreground">


### PR DESCRIPTION
Fixes #83 

1. Add clickable group context to notifications

![Screenshot from 2025-05-21 18-46-48](https://github.com/user-attachments/assets/6806774f-6a9b-45a2-a8ad-bc87467ec131)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added display of group information alongside notifications when available, including a badge linking to the relevant group.
- **Improvements**
  - Standardized and enriched group identification in notifications for more consistent and complete group references.
  - Updated terminology in notification settings from "communities" to "groups" for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->