### PR TITLE
replace kinds 1s with kind 11s on profiles

### DIFF
--- a/src/components/groups/PostList.tsx
+++ b/src/components/groups/PostList.tsx
@@ -133,7 +133,7 @@ export function PostList({ communityId, showOnlyApproved = false, pendingOnly = 
     queryFn: async (c) => {
       const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
       const posts = await nostr.query([{ 
-        kinds: [1, 11],
+        kinds: [11],
         "#a": [communityId],
         limit: 50,
       }], { signal });

--- a/src/components/groups/ReplyForm.tsx
+++ b/src/components/groups/ReplyForm.tsx
@@ -59,12 +59,12 @@ export function ReplyForm({
         
         // Root post reference (uppercase tags)
         ["E", postId],
-        ["K", "11"], // Original post is kind 11 (or 1 for backward compatibility)
+        ["K", "11"], // Original post is kind 11
         ["P", postAuthorPubkey],
         
         // Parent reference (lowercase tags)
         ["e", replyToId],
-        ["k", parentId ? "1111" : "11"], // Parent is either a reply (1111) or the original post (11 or 1)
+        ["k", parentId ? "1111" : "11"], // Parent is either a reply (1111) or the original post (11)
         ["p", replyToPubkey],
       ];
       

--- a/src/hooks/useLikes.ts
+++ b/src/hooks/useLikes.ts
@@ -52,7 +52,7 @@ export function useLikes(eventId: string) {
         kind: 7,
         tags: [
           ["e", eventId],
-          ["k", "1"], // Assuming we're liking a kind 1 post
+          ["k", "11"], // Assuming we're liking a kind 11 post
         ],
         content: "+", // "+" means like
       });

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -25,7 +25,7 @@ export function useNotifications() {
       const notifications: Notification[] = [];
       const readNotifications = JSON.parse(localStorage.getItem(`notifications:${user.pubkey}`) || '{}');
 
-      const kinds = [1, 7, 1111, 4550, 4551, 34550];
+      const kinds = [11, 7, 1111, 4550, 4551, 34550];
 
       const events = await nostr.query(
         [{ kinds, '#p': [user.pubkey], limit: 20 }],
@@ -39,7 +39,7 @@ export function useNotifications() {
         const groupId = communityParts && communityParts[0] === '34550' ? communityRef : undefined;
         
         switch (event.kind) {
-          case 1: {
+          case 11: {
             notifications.push({
               id: event.id,
               type: 'tag_post',

--- a/src/hooks/usePendingPostsCount.ts
+++ b/src/hooks/usePendingPostsCount.ts
@@ -25,7 +25,7 @@ export function usePendingPostsCount(communityId: string) {
       
       // Get posts that tag the community
       const posts = await nostr.query([{ 
-        kinds: [1, 11],
+        kinds: [11],
         "#a": [communityId],
         limit: 100,
       }], { signal });

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -170,7 +170,7 @@ export default function Profile() {
 
       // Get posts by this user
       const userPosts = await nostr.query([{
-        kinds: [1],
+        kinds: [11],
         authors: [pubkey],
         limit: 20,
       }], { signal });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated post queries and related features to only include posts of kind 11, excluding kind 1 across pending posts, notifications, likes, and user profiles.
- **Documentation**
	- Clarified comments in the reply form to accurately reference post kinds, removing outdated references to kind 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->