### PR TITLE
Add activity indicators to My Groups section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restored community activity indicators showing post count and participant count on group cards
 - Added loading states for community statistics while data is being fetched
 - Enhanced visual presentation of community metrics with badge-style elements
+- Added activity indicators to My Groups section showing post count and active participants
 
 ### Changed
 - Switched default relay to Chorus for better reliability
 - Group cards now display comprehensive activity metrics (moderators, posts, participants)
 - Improved UI consistency for community statistics with proper loading states
+- Enhanced My Groups display with consistent activity metrics across all group views
 
 ### Fixed
 - Various notification wording improvements and fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Switched default relay to Chorus for better reliability
-- Group cards now display comprehensive activity metrics (moderators, posts, participants)
+- Group cards now display focused activity metrics (posts and participants)
 - Improved UI consistency for community statistics with proper loading states
 - Enhanced My Groups display with consistent activity metrics across all group views
+- Removed moderator count badge to focus on activity metrics
 
 ### Fixed
 - Various notification wording improvements and fixes

--- a/src/components/groups/GroupCard.tsx
+++ b/src/components/groups/GroupCard.tsx
@@ -83,11 +83,6 @@ export function GroupCard({ community, isPinned, pinGroup, unpinGroup, isUpdatin
         <CardTitle>{name}</CardTitle>
         <CardDescription>
           <div className="flex flex-wrap gap-2 mt-1">
-            <div className="inline-flex items-center px-2 py-1 bg-muted rounded-md text-xs">
-              <Users className="h-3 w-3 mr-1" />
-              {moderatorTags.length} mod{moderatorTags.length !== 1 ? 's' : ''}
-            </div>
-            
             {isLoadingStats ? (
               <>
                 <div className="inline-flex items-center px-2 py-1 bg-muted rounded-md text-xs opacity-70">

--- a/src/components/groups/MyGroupCard.tsx
+++ b/src/components/groups/MyGroupCard.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Users, Pin, PinOff } from "lucide-react";
+import { Users, Pin, PinOff, MessageSquare, Activity } from "lucide-react";
 import { RoleBadge } from "@/components/groups/RoleBadge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -18,9 +18,14 @@ interface MyGroupCardProps {
   pinGroup: (communityId: string) => void;
   unpinGroup: (communityId: string) => void;
   isUpdating: boolean;
+  stats?: {
+    posts: number;
+    participants: Set<string>;
+  };
+  isLoadingStats?: boolean;
 }
 
-export function MyGroupCard({ community, role, isPinned, pinGroup, unpinGroup, isUpdating }: MyGroupCardProps) {
+export function MyGroupCard({ community, role, isPinned, pinGroup, unpinGroup, isUpdating, stats, isLoadingStats }: MyGroupCardProps) {
   const { user } = useCurrentUser();
   
   if (!user) return null;
@@ -93,9 +98,48 @@ export function MyGroupCard({ community, role, isPinned, pinGroup, unpinGroup, i
       </div>
       <CardHeader>
         <CardTitle>{name}</CardTitle>
-        <CardDescription className="flex items-center">
-          <Users className="h-4 w-4 mr-1" />
-          {moderatorTags.length} moderator{moderatorTags.length !== 1 ? 's' : ''}
+        <CardDescription>
+          <div className="flex flex-wrap gap-2 mt-1">
+            <div className="inline-flex items-center px-2 py-1 bg-muted rounded-md text-xs">
+              <Users className="h-3 w-3 mr-1" />
+              {moderatorTags.length} mod{moderatorTags.length !== 1 ? 's' : ''}
+            </div>
+            
+            {isLoadingStats ? (
+              <>
+                <div className="inline-flex items-center px-2 py-1 bg-muted rounded-md text-xs opacity-70">
+                  <MessageSquare className="h-3 w-3 mr-1" />
+                  Loading...
+                </div>
+                <div className="inline-flex items-center px-2 py-1 bg-muted rounded-md text-xs opacity-70">
+                  <Activity className="h-3 w-3 mr-1" />
+                  Loading...
+                </div>
+              </>
+            ) : stats ? (
+              <>
+                <div className="inline-flex items-center px-2 py-1 bg-muted rounded-md text-xs">
+                  <MessageSquare className="h-3 w-3 mr-1" />
+                  {stats.posts} post{stats.posts !== 1 ? 's' : ''}
+                </div>
+                <div className="inline-flex items-center px-2 py-1 bg-muted rounded-md text-xs">
+                  <Activity className="h-3 w-3 mr-1" />
+                  {stats.participants.size} participant{stats.participants.size !== 1 ? 's' : ''}
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="inline-flex items-center px-2 py-1 bg-muted rounded-md text-xs">
+                  <MessageSquare className="h-3 w-3 mr-1" />
+                  0 posts
+                </div>
+                <div className="inline-flex items-center px-2 py-1 bg-muted rounded-md text-xs">
+                  <Activity className="h-3 w-3 mr-1" />
+                  0 participants
+                </div>
+              </>
+            )}
+          </div>
         </CardDescription>
       </CardHeader>
       <CardContent className="flex-grow">

--- a/src/components/groups/MyGroupCard.tsx
+++ b/src/components/groups/MyGroupCard.tsx
@@ -100,11 +100,6 @@ export function MyGroupCard({ community, role, isPinned, pinGroup, unpinGroup, i
         <CardTitle>{name}</CardTitle>
         <CardDescription>
           <div className="flex flex-wrap gap-2 mt-1">
-            <div className="inline-flex items-center px-2 py-1 bg-muted rounded-md text-xs">
-              <Users className="h-3 w-3 mr-1" />
-              {moderatorTags.length} mod{moderatorTags.length !== 1 ? 's' : ''}
-            </div>
-            
             {isLoadingStats ? (
               <>
                 <div className="inline-flex items-center px-2 py-1 bg-muted rounded-md text-xs opacity-70">

--- a/src/components/groups/MyGroupsList.tsx
+++ b/src/components/groups/MyGroupsList.tsx
@@ -5,11 +5,56 @@ import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { usePinnedGroups } from "@/hooks/usePinnedGroups";
 import { MyGroupCard } from "./MyGroupCard";
 import { NostrEvent } from "@nostrify/nostrify";
+import { useNostr } from "@/hooks/useNostr";
+import { useQuery } from "@tanstack/react-query";
 
 export function MyGroupsList() {
   const { user } = useCurrentUser();
+  const { nostr } = useNostr();
   const { data: userGroups, isLoading } = useUserGroups();
   const { pinGroup, unpinGroup, isGroupPinned, isUpdating } = usePinnedGroups();
+  
+  // Query for community stats (posts and participants)
+  const { data: communityStats, isLoading: isLoadingStats } = useQuery({
+    queryKey: ["my-groups-stats", userGroups],
+    queryFn: async (c) => {
+      if (!userGroups || !userGroups.allGroups || userGroups.allGroups.length === 0 || !nostr) return {};
+      
+      const signal = AbortSignal.any([c.signal, AbortSignal.timeout(8000)]);
+      const stats: Record<string, { posts: number; participants: Set<string> }> = {};
+      
+      // Create a filter for all communities to get posts in a single query
+      const communityRefs = userGroups.allGroups.map(community => {
+        const dTag = community.tags.find(tag => tag[0] === "d");
+        return `34550:${community.pubkey}:${dTag ? dTag[1] : ""}`;
+      });
+      
+      // Get all posts that reference any community
+      const posts = await nostr.query([{ 
+        kinds: [1, 4550], 
+        "#a": communityRefs,
+        limit: 500
+      }], { signal });
+      
+      // Process posts to get stats for each community
+      posts.forEach(post => {
+        const communityTag = post.tags.find(tag => tag[0] === "a");
+        if (!communityTag) return;
+        
+        const communityId = communityTag[1];
+        if (!stats[communityId]) {
+          stats[communityId] = { posts: 0, participants: new Set() };
+        }
+        
+        // Count posts and unique participants
+        stats[communityId].posts++;
+        stats[communityId].participants.add(post.pubkey);
+      });
+      
+      return stats;
+    },
+    enabled: !!nostr && !!userGroups && !!userGroups.allGroups && userGroups.allGroups.length > 0,
+  });
 
   if (!user) {
     return null;
@@ -29,24 +74,6 @@ export function MyGroupsList() {
   if (!userGroups) {
     return null;
   }
-
-  const renderGroupCard = (community: NostrEvent, role: "pinned" | "owner" | "moderator" | "member") => {
-    const dTag = community.tags.find((tag: string[]) => tag[0] === "d");
-    const communityId = `34550:${community.pubkey}:${dTag ? dTag[1] : ""}`;
-    const isPinned = isGroupPinned(communityId);
-    
-    return (
-      <MyGroupCard
-        key={community.id}
-        community={community}
-        role={role}
-        isPinned={isPinned}
-        pinGroup={pinGroup}
-        unpinGroup={unpinGroup}
-        isUpdating={isUpdating}
-      />
-    );
-  };
 
   return (
     <div className="mb-8">
@@ -93,6 +120,8 @@ export function MyGroupsList() {
                 role = "moderator";
               }
               
+              const stats = communityStats ? communityStats[communityId] : undefined;
+              
               return (
                 <MyGroupCard
                   key={`${role}-${community.id}`}
@@ -102,6 +131,8 @@ export function MyGroupsList() {
                   pinGroup={pinGroup}
                   unpinGroup={unpinGroup}
                   isUpdating={isUpdating}
+                  stats={stats}
+                  isLoadingStats={isLoadingStats}
                 />
               );
             })}


### PR DESCRIPTION
## Summary
- Extended activity indicators (post count and participant count) to My Groups section
- Added loading states for statistics while data is being fetched
- Implemented consistent badge-style UI elements across all group displays
- Optimized data fetching with TanStack Query to make a single API call for all community stats

## Test plan
- Verify My Groups section displays stats badges for moderator count
- Check that post counts appear correctly for groups with activity
- Verify participant counts reflect unique users who have posted in the group
- Confirm loading states appear appropriately while data is being fetched
- Test with empty groups to ensure zero-state appears correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added activity indicators for post count and active participants to the "My Groups" section, providing consistent community metrics across all group views.
  - Updated group cards to focus activity metrics on posts and participants, removing the moderator count badge.

- **Documentation**
  - Updated the changelog to reflect the addition of activity indicators and enhancements to group activity metrics display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->